### PR TITLE
Load settings without modifying environment variables

### DIFF
--- a/geospaas_processing/__init__.py
+++ b/geospaas_processing/__init__.py
@@ -1,7 +1,7 @@
-"""Setup Django for the whole package"""
-import os
+"""Load Django configuration for the geospaas_processing module when it is used as standalone"""
+import django.conf
+from .settings import django_settings
 
-import django
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'geospaas_processing.settings')
-django.setup()
+if not django.conf.settings.configured:
+    django.conf.settings.configure(**django_settings)
+    django.setup()

--- a/geospaas_processing/apps.py
+++ b/geospaas_processing/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class GeospaasProcessingConfig(AppConfig):
+    name = 'geospaas_processing'

--- a/geospaas_processing/settings.py
+++ b/geospaas_processing/settings.py
@@ -1,34 +1,37 @@
-"""Settings for the harvesting daemon"""
+"""
+Settings for the harvesting daemon. They are defined in a dictionary,
+so that django.settings.configure() can easily be used.
+Also contains Celery settings.
+"""
 import os
 
-SECRET_KEY = os.getenv('SECRET_KEY', 'fake-key')
-
-INSTALLED_APPS = [
-    'geospaas.catalog',
-    'geospaas.vocabularies',
-    'django_celery_results'
-]
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'HOST': os.getenv('GEOSPAAS_DB_HOST', 'localhost'),
-        'PORT': os.getenv('GEOSPAAS_DB_PORT', '5432'),
-        'NAME': os.getenv('GEOSPAAS_DB_NAME', 'geodjango'),
-        'USER': os.getenv('GEOSPAAS_DB_USER', 'geodjango'),
-        'PASSWORD': os.getenv('GEOSPAAS_DB_PASSWORD'),
-        'CONN_MAX_AGE': 600
-    }
+django_settings = {
+    'SECRET_KEY': os.getenv('SECRET_KEY', 'fake-key'),
+    'INSTALLED_APPS': [
+        'geospaas.catalog',
+        'geospaas.vocabularies',
+        'django_celery_results'
+    ],
+    'DATABASES': {
+        'default': {
+            'ENGINE': 'django.contrib.gis.db.backends.postgis',
+            'HOST': os.getenv('GEOSPAAS_DB_HOST', 'localhost'),
+            'PORT': os.getenv('GEOSPAAS_DB_PORT', '5432'),
+            'NAME': os.getenv('GEOSPAAS_DB_NAME', 'geodjango'),
+            'USER': os.getenv('GEOSPAAS_DB_USER', 'geodjango'),
+            'PASSWORD': os.getenv('GEOSPAAS_DB_PASSWORD'),
+            'CONN_MAX_AGE': 600
+        }
+    },
+    # Internationalization
+    # https://docs.djangoproject.com/en/2.2/topics/i18n/
+    'LANGUAGE_CODE': 'en-us',
+    'TIME_ZONE': 'UTC',
+    'USE_I18N': True,
+    'USE_L10N': True,
+    'USE_TZ': True,
+    # Celery settings
+    'CELERY_BROKER_URL': os.getenv(
+        'GEOSPAAS_PROCESSING_BROKER', 'amqp://guest:guest@localhost:5672'),
+    'CELERY_RESULT_BACKEND': 'django-db'
 }
-
-# Internationalization
-# https://docs.djangoproject.com/en/2.2/topics/i18n/
-LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
-USE_I18N = True
-USE_L10N = True
-USE_TZ = True
-
-# Celery settings
-CELERY_BROKER_URL = os.getenv('GEOSPAAS_PROCESSING_BROKER', 'amqp://guest:guest@localhost:5672')
-CELERY_RESULT_BACKEND = 'django-db'

--- a/runtests.py
+++ b/runtests.py
@@ -4,20 +4,20 @@ Script used to run the unit tests for this package. A module of the 'tests' pack
 CLI argument, in which case only the tests in this module are run.
 """
 
-import os
 import sys
 
 import django
-from django.conf import settings
 from django.test.utils import get_runner
+from geospaas_processing.settings import django_settings
 
 if __name__ == "__main__":
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'geospaas_processing.settings'
-    django.setup()
+    if not django.conf.settings.configured:
+        django.conf.settings.configure(**django_settings)
+        django.setup()
 
     test_module = f".{sys.argv[1]}" if len(sys.argv) >= 2 else ''
 
-    TestRunner = get_runner(settings)
+    TestRunner = get_runner(django.conf.settings)
     test_runner = TestRunner()
     failures = test_runner.run_tests(["tests" + test_module])
     sys.exit(bool(failures))


### PR DESCRIPTION
Setting the `DJANGO_SETTINGS_MODULE` environment variable can have unintended consequences when using this app inside a Django project.