### PR TITLE
Don't decrement current downloads count if it wasn't incremented

### DIFF
--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -166,7 +166,7 @@ class DownloadLock():
 
     def __exit__(self, *args):
         """Decrements the number of downloads if necessary"""
-        if self.redis and self.acquired:
+        if self.redis and self.max_downloads and self.acquired:
             LOGGER.debug("Decrementing downloads count for %s", self.base_url)
             self.redis.eval(self.DECREMENT_SCRIPT, 1, self.CURRENT_DOWNLOADS_KEY, self.base_url)
 


### PR DESCRIPTION
If no maximum parallel downloads limit is specified, don't try to decrement the counter when exiting the lock