### PR TITLE
Add the idf converter in the worker Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
     - BASE_IMAGE_NAME="${DOCKER_ORG}/geospaas:v1.0.1"
     - IMAGE_NAME="${DOCKER_ORG}/geospaas_processing_worker"
+    - IDF_CONVERTER_VERSION=0.0.124
 jobs:
   include:
     - stage: 'Unit tests'
@@ -58,6 +59,11 @@ jobs:
       env:
         - DOCKER_TMP_TAG='tmp'
       install:
+        - >
+          curl -L -o ./idf_converter.tar.gz
+          -H "Authorization: token ${GITHUB_API_TOKEN}"
+          -H 'Accept: application/vnd.github.v3.raw'
+          "https://api.github.com/repos/nansencenter/idf-converter/contents/idf_converter-${IDF_CONVERTER_VERSION}.tar.gz"
         - docker pull "${IMAGE_NAME}" || true
       script:
         - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 
 env:
   global:
-    - BASE_IMAGE_NAME="${DOCKER_ORG}/geospaas:v1.0.1"
+    - BASE_IMAGE_NAME="${DOCKER_ORG}/geospaas:2.0.0-slim"
     - IMAGE_NAME="${DOCKER_ORG}/geospaas_processing_worker"
     - IDF_CONVERTER_VERSION=0.0.124
 jobs:
@@ -47,9 +47,7 @@ jobs:
           -e "GEOSPAAS_DB_USER=$GEOSPAAS_DB_USER" -e "GEOSPAAS_DB_PASSWORD=$GEOSPAAS_DB_PASSWORD"
           --entrypoint bash
           "${IMAGE_NAME}"
-          -c "source /opt/conda/bin/activate
-          && coverage run --source=./geospaas_processing /src/runtests.py
-          && coveralls"
+          -c "coverage run --source=./geospaas_processing /src/runtests.py && coveralls"
       after_script:
         - docker stop "$GEOSPAAS_DB_HOST"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN pip install --no-cache-dir \
 
 FROM base as full
 
+COPY idf_converter.tar.gz /tmp/idf_converter.tar.gz
+RUN pip install /tmp/idf_converter.tar.gz
+
 WORKDIR /tmp/setup
 COPY setup.py README.md ./
 COPY geospaas_processing ./geospaas_processing

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install --no-cache-dir \
     celery==4.4 \
     django-celery-results==1.2 \
     graypy==2.1.0 \
-    paramiko==2.7.1 \
+    paramiko==2.7.2 \
     redis==3.5 \
     scp==0.13.2
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The `geospaas_processing` package offers the options to run the processing modul
 
 ### Architecture
 
-Here is a description of thr architecture in which `geospaas_processing` is supposed to be used.
+Here is a description of the architecture in which `geospaas_processing` is supposed to be used.
 
 The components are:
   - a Celery worker
@@ -175,7 +175,15 @@ geospaas_processing.tasks.download.delay((180,))
 
 #### `convert_to_idf()`
 
-TODO
+Converts a dataset to the IDF format for usage in Oceandatalab's
+[SEAScope](https://seascope.oceandatalab.com/index.html).
+
+Argument: a two-elements tuple containing the ID of the dataset and the path to the file to convert.
+
+```python
+# Asynchronously convert the dataset whose ID is 180
+geospaas_processing.tasks.convert_to_idf.delay((180, './dataset_180.nc'))
+```
 
 #### `archive()`
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/nansencenter/django-geo-spaas-processing",
-    packages=setuptools.find_packages(),
+    packages=["geospaas_processing"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(os.path.join(os.path.dirname(__file__), "README.md"), "r") as fh:
 
 setuptools.setup(
     name="geospaas_processing",
-    version="0.0.3",
+    version="0.0.4",
     author="Adrien Perrin",
     author_email="adrien.perrin@nersc.no",
     description="Processing tools for GeoSPaaS",

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
     ],
     python_requires='>=3.7',
     install_requires=['django-geo-spaas', 'paramiko', 'scp'],
-    package_data={'': ['*.yml', 'parameters/*']},
+    package_data={'': ['*.yml', 'auxiliary/*', 'parameters/*']},
 )

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
     ],
     python_requires='>=3.7',
     install_requires=['django-geo-spaas', 'paramiko', 'scp'],
-    package_data={'': ['*.yml']},
+    package_data={'': ['*.yml', 'parameters/*']},
 )


### PR DESCRIPTION
Resolves #14 

Also:
- use the slim geospaas image as base.
- update the paramiko version in 2.7.2 in the Docker image (necessary for it work with the Anaconda python used in the slim image).
- a few modifications to `setup.py` to include all the necessary files in the package, and only those.
- add documentation for the `convert_to_idf()` task in the README.