### PR TITLE
Issue21 saving the file address after downloading

### DIFF
--- a/geospaas_processing/cli/download.py
+++ b/geospaas_processing/cli/download.py
@@ -30,6 +30,7 @@ def main():
         provider_settings_path=arg.config_file,
         max_downloads=int(arg.safety_limit),
         use_file_prefix=arg.use_filename_prefix,
+        store_address=arg.address_storage,
         time_coverage_start__gte=designated_begin,
         time_coverage_end__lte=designated_end,
         **cumulative_query
@@ -79,6 +80,10 @@ def cli_parse_args():
         '-p', '--use_filename_prefix', action='store_true',
         help="The flag that distinguishes between the two cases of having files WITH or WITHOUT "
         + "file prefix when downloaded")
+    parser.add_argument(
+        '-a', '--address_storage', action='store_true',
+        help="The flag that distinguishes between the two cases of whether storing the local "
+        + "address of file in the dataset or not by its its ABSENCE or PRESENCE in the arguments.")
     parser.add_argument(
         '-g', '--geometry', required=False, type=str,
         help="The 'wkt' string of geometry which is acceptable by 'GEOSGeometry' of django")

--- a/geospaas_processing/cli/download.py
+++ b/geospaas_processing/cli/download.py
@@ -30,7 +30,7 @@ def main():
         provider_settings_path=arg.config_file,
         max_downloads=int(arg.safety_limit),
         use_file_prefix=arg.use_filename_prefix,
-        store_address=arg.address_storage,
+        save_path=arg.save_path,
         time_coverage_start__gte=designated_begin,
         time_coverage_end__lte=designated_end,
         **cumulative_query
@@ -81,9 +81,8 @@ def cli_parse_args():
         help="The flag that distinguishes between the two cases of having files WITH or WITHOUT "
         + "file prefix when downloaded")
     parser.add_argument(
-        '-a', '--address_storage', action='store_true',
-        help="The flag that distinguishes between the two cases of whether storing the local "
-        + "address of file in the dataset or not by its ABSENCE or PRESENCE in the arguments.")
+        '-a', '--save_path', action='store_true',
+        help="Save path to local file in the database based on its ABSENCE or PRESENCE.")
     parser.add_argument(
         '-g', '--geometry', required=False, type=str,
         help="The 'wkt' string of geometry which is acceptable by 'GEOSGeometry' of django")

--- a/geospaas_processing/cli/download.py
+++ b/geospaas_processing/cli/download.py
@@ -83,7 +83,7 @@ def cli_parse_args():
     parser.add_argument(
         '-a', '--address_storage', action='store_true',
         help="The flag that distinguishes between the two cases of whether storing the local "
-        + "address of file in the dataset or not by its its ABSENCE or PRESENCE in the arguments.")
+        + "address of file in the dataset or not by its ABSENCE or PRESENCE in the arguments.")
     parser.add_argument(
         '-g', '--geometry', required=False, type=str,
         help="The 'wkt' string of geometry which is acceptable by 'GEOSGeometry' of django")

--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -275,6 +275,8 @@ class DownloadManager():
         Returns the downloaded file path if the download succeeds, an empty string otherwise.
         """
         for dataset_uri in dataset.dataseturi_set.all():
+            if dataset_uri.service==geospaas.catalog.managers.LOCAL_FILE_SERVICE:
+                continue
             # Get the extra settings for the provider
             dataset_uri_prefix = "://".join(requests.utils.urlparse(dataset_uri.uri)[0:2])
             # Find provider settings

--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -275,7 +275,7 @@ class DownloadManager():
         Returns the downloaded file path if the download succeeds, an empty string otherwise.
         """
         for dataset_uri in dataset.dataseturi_set.all():
-            if dataset_uri.service==geospaas.catalog.managers.LOCAL_FILE_SERVICE:
+            if dataset_uri.service == geospaas.catalog.managers.LOCAL_FILE_SERVICE:
                 continue
             # Get the extra settings for the provider
             dataset_uri_prefix = "://".join(requests.utils.urlparse(dataset_uri.uri)[0:2])
@@ -323,7 +323,7 @@ class DownloadManager():
                         if self.save_path:
                             dataset.dataseturi_set.get_or_create(
                                 dataset=dataset,
-                                uri = os.path.join(download_directory, file_name),
+                                uri = os.path.join(os.path.realpath(download_directory), file_name),
                                 )
                         LOGGER.info("Successfully downloaded dataset %d to %s",
                                     dataset.pk, file_name)

--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -238,7 +238,7 @@ class DownloadManager():
     }
 
     def __init__(self, download_directory='.', provider_settings_path=None, max_downloads=100,
-                 use_file_prefix=True, store_address=False, **criteria):
+                 use_file_prefix=True, save_path=False, **criteria):
         """
         `criteria` accepts the same keyword arguments as Django's `filter()` method.
         When filtering on time coverage, it is preferable to use timezone aware datetimes.
@@ -251,7 +251,7 @@ class DownloadManager():
             raise DownloadError("No dataset matches the search criteria")
         self.download_folder = download_directory
         self.use_file_prefix = use_file_prefix
-        self.store_address = store_address
+        self.save_path = save_path
         LOGGER.debug("Found %d datasets", self.datasets.count())
         if self.datasets.count() > self.max_downloads:
             raise ValueError("Too many datasets to download")
@@ -318,10 +318,10 @@ class DownloadManager():
                         f"Could not write the dowloaded file to {error.filename}") from error
                 else:
                     if downloaded:
-                        if self.store_address:
-                            dataset.dataseturi_set.update_or_create(
-                                service='DOWNLOAD_DIR', dataset=dataset,
-                                defaults={"uri": os.path.join(download_directory, file_name)}
+                        if self.save_path:
+                            dataset.dataseturi_set.get_or_create(
+                                dataset=dataset,
+                                uri = os.path.join(download_directory, file_name),
                                 )
                         LOGGER.info("Successfully downloaded dataset %d to %s",
                                     dataset.pk, file_name)

--- a/tests/data/test_data.json
+++ b/tests/data/test_data.json
@@ -95,6 +95,26 @@
         }
     },
     {
+        "model": "catalog.dataseturi",
+        "pk": 5,
+        "fields": {
+            "name": "fileService",
+            "service": "local",
+            "uri": "/testing_folder/testing_file.test",
+            "dataset": 2
+        }
+    },
+    {
+        "model": "catalog.dataseturi",
+        "pk": 6,
+        "fields": {
+            "name": "http",
+            "service": "HTTPServer",
+            "uri": "https://scihub.copernicus.eu/the_second_fakeurl",
+            "dataset": 2
+        }
+    },
+    {
         "model": "vocabularies.platform",
         "pk": 1,
         "fields": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,14 +45,14 @@ class DownlaodingCLITestCase(unittest.TestCase):
                          +'"source__instrument__short_name__icontains": "AMSR2"}')
         # testing the flag enumeration
         self.assertTrue(arg.rel_time_flag)
+        self.assertTrue(arg.save_path)
         self.assertTrue(arg.use_filename_prefix)
-        self.assertTrue(arg.address_storage)
         sys.argv.remove('-r')
         sys.argv.remove('-a')
         sys.argv.remove('-p')
         arg = cli_download.cli_parse_args()
         self.assertFalse(arg.rel_time_flag)
-        self.assertFalse(arg.address_storage)
+        self.assertFalse(arg.save_path)
         self.assertFalse(arg.use_filename_prefix)
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
@@ -69,8 +69,7 @@ class DownlaodingCLITestCase(unittest.TestCase):
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
     @mock.patch('geospaas_processing.downloaders.DownloadManager.download')
-    def test_lack_of_calling_json_deserializer_when_no_query_appears(
-            self, mock_download_method, mock_download_manager_init):
+    def test_lack_of_calling_json_deserializer_when_no_query_appears(self, mock_download_method, mock_download_manager_init):
         """'json.loads' should not called when nothing comes after '-q' """
         sys.argv.pop()
         sys.argv.pop()
@@ -99,7 +98,7 @@ class DownlaodingCLITestCase(unittest.TestCase):
             'dataseturi__uri__contains': 'osisaf',
             'source__instrument__short_name__icontains': 'AMSR2',
             'use_file_prefix': False,
-            'store_address': True
+            'save_path': True
         }, mock_download_manager_init.call_args)
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
@@ -124,7 +123,7 @@ class DownlaodingCLITestCase(unittest.TestCase):
             'dataseturi__uri__contains': 'osisaf',
             'source__instrument__short_name__icontains': 'AMSR2',
             'use_file_prefix': True,
-            'store_address': True
+            'save_path': True
         }, mock_download_manager_init.call_args)
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
@@ -147,7 +146,7 @@ class DownlaodingCLITestCase(unittest.TestCase):
             'dataseturi__uri__contains': 'osisaf',
             'source__instrument__short_name__icontains': 'AMSR2',
             'use_file_prefix': True,
-            'store_address': True
+            'save_path': True
         }, mock_download_manager_init.call_args)
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
@@ -170,7 +169,7 @@ class DownlaodingCLITestCase(unittest.TestCase):
             'dataseturi__uri__contains': 'osisaf',
             'source__instrument__short_name__icontains': 'AMSR2',
             'use_file_prefix': True,
-            'store_address': True
+            'save_path': True
         }, mock_download_manager_init.call_args)
 
     def test_find_designated_time_function(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,8 @@ class DownlaodingCLITestCase(unittest.TestCase):
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
     @mock.patch('geospaas_processing.downloaders.DownloadManager.download')
-    def test_lack_of_calling_json_deserializer_when_no_query_appears(self, mock_download_method, mock_download_manager_init):
+    def test_lack_of_calling_json_deserializer_when_no_query_appears(
+        self, mock_download_method, mock_download_manager_init):
         """'json.loads' should not called when nothing comes after '-q' """
         sys.argv.pop()
         sys.argv.pop()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ class DownlaodingCLITestCase(unittest.TestCase):
             '-b', "200",
             '-e', "2020-08-22",
             '-r',
+            '-a',
             '-s', "100",
             '-p',
             '-g', "POLYGON ((-22 84, -22 74, 32 74, 32 84, -22 84))",
@@ -45,10 +46,13 @@ class DownlaodingCLITestCase(unittest.TestCase):
         # testing the flag enumeration
         self.assertTrue(arg.rel_time_flag)
         self.assertTrue(arg.use_filename_prefix)
+        self.assertTrue(arg.address_storage)
         sys.argv.remove('-r')
+        sys.argv.remove('-a')
         sys.argv.remove('-p')
         arg = cli_download.cli_parse_args()
         self.assertFalse(arg.rel_time_flag)
+        self.assertFalse(arg.address_storage)
         self.assertFalse(arg.use_filename_prefix)
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
@@ -94,7 +98,8 @@ class DownlaodingCLITestCase(unittest.TestCase):
             'time_coverage_start__gte': datetime(2019, 10, 22, 0, 0, tzinfo=tzutc()),
             'dataseturi__uri__contains': 'osisaf',
             'source__instrument__short_name__icontains': 'AMSR2',
-            'use_file_prefix': False
+            'use_file_prefix': False,
+            'store_address': True
         }, mock_download_manager_init.call_args)
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
@@ -118,7 +123,8 @@ class DownlaodingCLITestCase(unittest.TestCase):
             'time_coverage_start__gte': datetime(2019, 10, 22, 0, 0, tzinfo=tzutc()),
             'dataseturi__uri__contains': 'osisaf',
             'source__instrument__short_name__icontains': 'AMSR2',
-            'use_file_prefix': True
+            'use_file_prefix': True,
+            'store_address': True
         }, mock_download_manager_init.call_args)
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
@@ -140,7 +146,8 @@ class DownlaodingCLITestCase(unittest.TestCase):
             'time_coverage_start__gte': datetime(2019, 10, 22, 0, 0, tzinfo=tzutc()),
             'dataseturi__uri__contains': 'osisaf',
             'source__instrument__short_name__icontains': 'AMSR2',
-            'use_file_prefix': True
+            'use_file_prefix': True,
+            'store_address': True
         }, mock_download_manager_init.call_args)
 
     @mock.patch('geospaas_processing.downloaders.DownloadManager.__init__', return_value=None)
@@ -162,7 +169,8 @@ class DownlaodingCLITestCase(unittest.TestCase):
             'time_coverage_start__gte': datetime(2012, 1, 12, 8, 0, tzinfo=tzutc()),
             'dataseturi__uri__contains': 'osisaf',
             'source__instrument__short_name__icontains': 'AMSR2',
-            'use_file_prefix': True
+            'use_file_prefix': True,
+            'store_address': True
         }, mock_download_manager_init.call_args)
 
     def test_find_designated_time_function(self):

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -384,6 +384,19 @@ class DownloadManagerTestCase(django.test.TestCase):
             download_manager.download_dataset(dataset, 'testing_value')
             self.assertIsNone(mock_dl_url.call_args[1]['file_prefix'])
 
+    def test_the_storing_ability_of_file_local_address(self):
+        """
+        Test that address of downloaded file is added to the dataseturi model
+        with attribute of "service='DOWNLOAD_DIR'".
+        """
+        download_manager = downloaders.DownloadManager(store_address=True)
+        dataset = Dataset.objects.get(pk=1)
+        with mock.patch.object(downloaders.HTTPDownloader, 'check_and_download_url') as mock_dl_url:
+            mock_dl_url.return_value = ('test.nc', True)
+            download_manager.download_dataset(dataset, 'testing_value')
+            self.assertEqual(dataset.dataseturi_set.get(service='DOWNLOAD_DIR').uri,
+                            'testing_value/test.nc')
+
     def test_download_dataset(self):
         """Test that a dataset is downloaded with the correct arguments"""
         download_manager = downloaders.DownloadManager(

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -13,6 +13,7 @@ import geospaas_processing.downloaders as downloaders
 import geospaas_processing.utils as utils
 import requests
 from geospaas.catalog.models import Dataset
+from geospaas.catalog.managers import LOCAL_FILE_SERVICE
 from redis import Redis
 
 class DownloaderTestCase(unittest.TestCase):
@@ -386,15 +387,15 @@ class DownloadManagerTestCase(django.test.TestCase):
 
     def test_the_storing_ability_of_file_local_address(self):
         """
-        Test that address of downloaded file is added to the dataseturi model
-        with attribute of "service='DOWNLOAD_DIR'".
+        Test that address of downloaded file is added to the dataseturi model.
         """
-        download_manager = downloaders.DownloadManager(store_address=True)
+        download_manager = downloaders.DownloadManager(save_path=True)
         dataset = Dataset.objects.get(pk=1)
         with mock.patch.object(downloaders.HTTPDownloader, 'check_and_download_url') as mock_dl_url:
             mock_dl_url.return_value = ('test.nc', True)
             download_manager.download_dataset(dataset, 'testing_value')
-            self.assertEqual(dataset.dataseturi_set.get(service='DOWNLOAD_DIR').uri,
+            self.assertEqual(dataset.dataseturi_set.filter(
+                                dataset=dataset,service=LOCAL_FILE_SERVICE)[0].uri,
                             'testing_value/test.nc')
 
     def test_download_dataset(self):

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -463,7 +463,7 @@ class DownloadManagerTestCase(django.test.TestCase):
                 self.assertEqual(download_manager.download_dataset(dataset, ''), dataset_file_name)
                 self.assertTrue(logs_cm.records[0].message.startswith('Failed to download dataset'))
 
-    def test_download_dataset_failure_when_no_local_link_is_stored(self):
+    def test_download_dataset_having_local_link_fails_because_of_corrupted_uri(self):
         """Test that `download_dataset` raises a DownloadError exception if the download failed"""
         download_manager = downloaders.DownloadManager()
         dataset = Dataset.objects.get(pk=2)
@@ -473,7 +473,7 @@ class DownloadManagerTestCase(django.test.TestCase):
                 with self.assertLogs(downloaders.LOGGER, logging.WARNING):
                     download_manager.download_dataset(dataset, '')
 
-    def test_download_dataset_failureno_when_local_link_is_stored_as_dataseturi(self):
+    def test_download_dataset_without_local_link_fails_because_of_corrupted_uri(self):
         """Test that `download_dataset` raises a DownloadError exception if the download failed"""
         download_manager = downloaders.DownloadManager()
         dataset = Dataset.objects.get(pk=1)

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -390,7 +390,7 @@ class DownloadManagerTestCase(django.test.TestCase):
         Test that address of downloaded file is added to the dataseturi model.
         """
         download_manager = downloaders.DownloadManager(save_path=True)
-        dataset = Dataset.objects.get(pk=1)
+        dataset = Dataset.objects.get(pk=3)
         with mock.patch.object(downloaders.HTTPDownloader, 'check_and_download_url') as mock_dl_url:
             mock_dl_url.return_value = ('test.nc', True)
             download_manager.download_dataset(dataset, 'testing_value')
@@ -463,7 +463,17 @@ class DownloadManagerTestCase(django.test.TestCase):
                 self.assertEqual(download_manager.download_dataset(dataset, ''), dataset_file_name)
                 self.assertTrue(logs_cm.records[0].message.startswith('Failed to download dataset'))
 
-    def test_download_dataset_failure(self):
+    def test_download_dataset_failure_when_no_local_link_is_stored(self):
+        """Test that `download_dataset` raises a DownloadError exception if the download failed"""
+        download_manager = downloaders.DownloadManager()
+        dataset = Dataset.objects.get(pk=2)
+        with mock.patch.object(downloaders.HTTPDownloader, 'check_and_download_url') as mock_dl_url:
+            mock_dl_url.side_effect = downloaders.DownloadError
+            with self.assertRaises(downloaders.DownloadError):
+                with self.assertLogs(downloaders.LOGGER, logging.WARNING):
+                    download_manager.download_dataset(dataset, '')
+
+    def test_download_dataset_failureno_when_local_link_is_stored_as_dataseturi(self):
         """Test that `download_dataset` raises a DownloadError exception if the download failed"""
         download_manager = downloaders.DownloadManager()
         dataset = Dataset.objects.get(pk=1)


### PR DESCRIPTION
@aperrin66 
@akorosov 
Since the database is the most important source of information for us and since [as a second reason :)  ] we must take care of staleness of data in the database, I have used `update_or_create` of django for adding the new record in the dataset_uri model. This way, the local address of recent successful download action is stored and we will not be worry about the staleness of the address in the database. And at the same time we have only address which is achievable by using the `get` function of django.

One more test is also added to cover this functionality.