### PR TITLE
#30 deleter_code_with_tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The processing modules can either be run as standalone code or asynchronously as
 | '-l'                |                         | '--link'
 | '-t'                |                         | '--type'
 | '-f'                |                         | '--flag_file'
+| '-k'                |                         | '--keeping_permanently'
+| '-o'                |                         | '--obsoleteness'
 ---
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The processing modules can either be run as standalone code or asynchronously as
 | '-t'                |                         | '--type'
 | '-f'                |                         | '--flag_file'
 | '-k'                |                         | '--keeping_permanently'
-| '-o'                |                         | '--obsoleteness'
+| '-ttl'              |                         | '--time_to_live'
 ---
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The processing modules can either be run as standalone code or asynchronously as
 | '-l'                |                         | '--link'
 | '-t'                |                         | '--type'
 | '-f'                |                         | '--flag_file'
-| '-k'                |                         | '--keeping_permanently'
 | '-ttl'              |                         | '--time_to_live'
 ---
 ## Dependencies

--- a/geospaas_processing/cli/copy.py
+++ b/geospaas_processing/cli/copy.py
@@ -17,9 +17,8 @@ def main():
                                         flag_file_request=arg.flag_file,
                                         link_request=arg.link,
                                         destination_path=arg.destination_path,
-                                        time_to_live=int(arg.time_to_live),
-                                        keep_permanently=arg.keeping_permanently,
                                         **cumulative_query)
+    current_copy_action.delete(int(arg.time_to_live))
     current_copy_action.copy()
 
 
@@ -39,11 +38,6 @@ def cli_parse_args():
     parser.add_argument(
         '-t', '--type', required=False, type=str,
         help="The type of dataset (as a str) which is written in flag file for further processing.")
-    parser.add_argument(
-        '-k', '--keeping_permanently', required=False, action='store_true',
-        help="The flag that distinguishes between the two cases of 1.deletion of the previously "
-        + "copied file(s) after a certain period of time or 2.do nothing regarding deletion based "
-        + "on its ABSENCE or PRESENCE of this flag in the arguments.")
     parser.add_argument(
         '-ttl', '--time_to_live', required=False, type=str, default="90",
         help="The upper limit [in days] of file existence that have already been copied."

--- a/geospaas_processing/cli/copy.py
+++ b/geospaas_processing/cli/copy.py
@@ -17,11 +17,10 @@ def main():
                                         flag_file_request=arg.flag_file,
                                         link_request=arg.link,
                                         destination_path=arg.destination_path,
-                                        obsoleteness=int(arg.obsoleteness),
+                                        time_to_live=int(arg.time_to_live),
+                                        keep_permanently=arg.keeping_permanently,
                                         **cumulative_query)
     current_copy_action.copy()
-    if not arg.keeping_permanently:
-        current_copy_action.delete()
 
 
 def cli_parse_args():
@@ -46,8 +45,8 @@ def cli_parse_args():
         + "copied file(s) after a certain period of time or 2.do nothing regarding deletion based "
         + "on its ABSENCE or PRESENCE of this flag in the arguments.")
     parser.add_argument(
-        '-o', '--obsoleteness', required=False, type=str, default="90",
-        help="The upper limit of days of file existence that are being copied."
+        '-ttl', '--time_to_live', required=False, type=str, default="90",
+        help="The upper limit [in days] of file existence that have already been copied."
         + " If the file is older than this limit, it will be deleted.")
     return parser.parse_args()
 

--- a/geospaas_processing/cli/copy.py
+++ b/geospaas_processing/cli/copy.py
@@ -17,8 +17,11 @@ def main():
                                         flag_file_request=arg.flag_file,
                                         link_request=arg.link,
                                         destination_path=arg.destination_path,
+                                        obsoleteness=int(arg.obsoleteness),
                                         **cumulative_query)
     current_copy_action.copy()
+    if not arg.keeping_permanently:
+        current_copy_action.delete()
 
 
 def cli_parse_args():
@@ -37,6 +40,15 @@ def cli_parse_args():
     parser.add_argument(
         '-t', '--type', required=False, type=str,
         help="The type of dataset (as a str) which is written in flag file for further processing.")
+    parser.add_argument(
+        '-k', '--keeping_permanently', required=False, action='store_true',
+        help="The flag that distinguishes between the two cases of 1.deletion of the previously "
+        + "copied file(s) after a certain period of time or 2.do nothing regarding deletion based "
+        + "on its ABSENCE or PRESENCE of this flag in the arguments.")
+    parser.add_argument(
+        '-o', '--obsoleteness', required=False, type=str, default="90",
+        help="The upper limit of days of file existence that are being copied."
+        + " If the file is older than this limit, it will be deleted.")
     return parser.parse_args()
 
 

--- a/geospaas_processing/cli/delete_and_copy.py
+++ b/geospaas_processing/cli/delete_and_copy.py
@@ -1,5 +1,6 @@
 """
-Copy files that are selected from the database using input criteria from copy config file.
+first delete the old ones and then copy files that are selected from the database using input
+criteria from copy config file.
 """
 import geospaas_processing.cli.util as util
 import geospaas_processing.copiers as copiers

--- a/geospaas_processing/copiers.py
+++ b/geospaas_processing/copiers.py
@@ -17,14 +17,12 @@ LOGGER = logging.getLogger(__name__)
 class Copier():
     """Copier for datasets"""
 
-    def __init__(self, type_in_flag_file, destination_path, time_to_live, keep_permanently,
+    def __init__(self, type_in_flag_file, destination_path,
     flag_file_request=False, link_request=False, **criteria):
         self._type_in_flag_file = type_in_flag_file
         self._destination_path = destination_path
         self._flag_file_request = flag_file_request
         self._link_request = link_request
-        self.ttl = time_to_live
-        self.keep_permanently = keep_permanently
         self._datasets = Dataset.objects.filter(**criteria)
 
     @staticmethod
@@ -71,10 +69,7 @@ class Copier():
                     " there is no file in the stored address: %s.", dataset.id, source_path.uri)
 
     def copy(self):
-        """ First delete the old files then tries to copy all datasets based on their stored local
-        addresses in the database."""
-        if not self.keep_permanently:
-            self.delete()
+        """ Tries to copy all datasets based on their stored local addresses in the database."""
         for dataset in self._datasets:
             if dataset.dataseturi_set.filter(service=LOCAL_FILE_SERVICE).exists():
                 source_paths = dataset.dataseturi_set.filter(service=LOCAL_FILE_SERVICE)
@@ -83,7 +78,7 @@ class Copier():
                 LOGGER.debug("For dataset with id = %s, there is no local file address in the "
                              "database.", dataset.id)
 
-    def delete(self):
+    def delete(self, ttl):
         """
         Delete the file(s) or symlink(s) after a certain period of 'time to live' (in days) of the
         file(s) or symlink(s) inside the destination path. """
@@ -92,5 +87,5 @@ class Copier():
                 if ((entry.is_file(follow_symlinks=False) or entry.is_symlink())
                     and '.snapshot' not in entry.path
                     and entry.stat(follow_symlinks=False).st_uid == os.getuid()
-                    and time.time() - entry.stat(follow_symlinks=False).st_mtime > self.ttl*24*3600):
+                    and time.time() - entry.stat(follow_symlinks=False).st_mtime > ttl*24*3600):
                         os.remove(entry.path)

--- a/geospaas_processing/copiers.py
+++ b/geospaas_processing/copiers.py
@@ -57,7 +57,7 @@ class Copier():
                     else:
                         shutil.copy(src=source_path.uri, dst=self._destination_path)
                     if self._flag_file_request:
-                       self.write_flag_file(self._type_in_flag_file,
+                        self.write_flag_file(self._type_in_flag_file,
                                              source_path, dataset, destination_filename)
                 else:
                     LOGGER.debug(

--- a/geospaas_processing/copiers.py
+++ b/geospaas_processing/copiers.py
@@ -18,7 +18,7 @@ class Copier():
     """Copier for datasets"""
 
     def __init__(self, type_in_flag_file, destination_path,
-    flag_file_request=False, link_request=False, **criteria):
+                 flag_file_request=False, link_request=False, **criteria):
         self._type_in_flag_file = type_in_flag_file
         self._destination_path = destination_path
         self._flag_file_request = flag_file_request

--- a/geospaas_processing/copiers.py
+++ b/geospaas_processing/copiers.py
@@ -81,11 +81,12 @@ class Copier():
     def delete(self, ttl):
         """
         Delete the file(s) or symlink(s) after a certain period of 'time to live' (in days) of the
-        file(s) or symlink(s) inside the destination path. """
+        file(s) or symlink(s) inside the destination path.
+        """
         with os.scandir(self._destination_path) as scanned_dir:
             for entry in scanned_dir:
                 if ((entry.is_file(follow_symlinks=False) or entry.is_symlink())
                     and '.snapshot' not in entry.path
                     and entry.stat(follow_symlinks=False).st_uid == os.getuid()
                     and time.time() - entry.stat(follow_symlinks=False).st_mtime > ttl*24*3600):
-                        os.remove(entry.path)
+                    os.remove(entry.path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,45 +301,35 @@ class CopyingCLITestCase(django.test.TestCase):
 
     def test_delete_all_files_and_symlinks_in_destination_folder(self):
         """ delete function should delete both file(s) and symlink(s) in destination folder. In this
-        test a temporary file and a symlink of it is created. Both of them should be deleted."""
+        test a temporary file and a symlink of it is created. Both of them should be deleted.
+        """
         with tempfile.TemporaryDirectory() as tmpdirname:
             with tempfile.NamedTemporaryFile(dir=tmpdirname) as tmpfile:
                 os.symlink(src=tmpfile.name, dst=tmpfile.name + '_symlink')  # symlink creation
-                sys.argv = [
-                    "",
-                    '-b', "2038-06-01",
-                    '-e', "2038-06-09",
-                    '-d', tmpdirname,
-                    "--time_to_live", "0"
-                ]
-                with mock.patch('shutil.copy'):
-                    with mock.patch('os.remove') as mock_os_remove:
-                        cli_copy.main()
-            os.remove(tmpfile.name + '_symlink')
-        self.assertCountEqual([call(tmpfile.name), call(tmpfile.name + '_symlink')],
-                              mock_os_remove.call_args_list)
+                copier = geospaas_processing.copiers.Copier('type1', tmpdirname)
+                with mock.patch('os.remove') as mock_os_remove:
+                    copier.delete(0)
+                    self.assertCountEqual([call(tmpfile.name), call(tmpfile.name + '_symlink')],
+                                        mock_os_remove.call_args_list)
 
-    @mock.patch('shutil.copy')
-    def test_deleting_symlinks_without_a_reference_file(self, mock_copy):
-        """ delete function should delete the symlink(s) regardless of the state of existence of the
-        reference file. In this test, the symlink is existing without a reference file. The test
-        shall remove that symlink."""
+    def test_deleting_symlinks_without_a_reference_file(self):
+        """
+        delete function should also delete the symlink(s) regardless of the state of existence of
+        the reference file. In this test, the symlink is existing without a reference file. The test
+        shall remove that symlink.
+        """
         with tempfile.TemporaryDirectory() as tmpdirname:
+            copier = geospaas_processing.copiers.Copier('type1', tmpdirname)
             path_of_file = os.path.join(tmpdirname, 'test_file_name')
             Path(path_of_file).touch()
             symlink_path = path_of_file + '_symlink'
             os.symlink(src=path_of_file, dst=symlink_path)  # symlink creation
             os.remove(path_of_file)  # remove the reference file of the symlink
-            sys.argv = [
-                "",
-                '-b', "2038-06-01",
-                '-e', "2038-06-09",
-                '-d', tmpdirname,
-                "--time_to_live", "0"
-            ]
-            with mock.patch('os.remove')as mock_os_remove:
-                cli_copy.main()
-            self.assertEqual(call(symlink_path), mock_os_remove.call_args)
+            with mock.patch('os.remove') as mock_os_remove:
+                copier.delete(0)
+                self.assertEqual(call(symlink_path), mock_os_remove.call_args)
+
+
 
     @mock.patch('os.symlink')
     @mock.patch('os.path.isfile', return_value=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -310,7 +310,7 @@ class CopyingCLITestCase(django.test.TestCase):
             with tempfile.NamedTemporaryFile(dir=tmpdirname) as tmpfile:
                 os.symlink(src=tmpfile.name, dst=tmpfile.name + '_symlink')  # symlink creation
                 broken_symlink_path = os.path.join(tmpdirname, 'broken_symlink')
-                os.symlink(src='/tmp/blah', dst=broken_symlink_path)
+                os.symlink(src=tmpdirname+'/blablablah', dst=broken_symlink_path)
                 copier = geospaas_processing.copiers.Copier('type1', tmpdirname)
                 with mock.patch('os.remove') as mock_os_remove:
                     copier.delete(0)
@@ -347,5 +347,4 @@ class CopyingCLITestCase(django.test.TestCase):
                 "e\n- url: https://scihub.copernicus.eu/the_second_fakeurl\nsummary: Date: 2018-04-"
                 "05T00:43:05.826008Z, Instrument: SLSTR, Mode: EO, Satellite: Sentinel-3, Size: 415"
                 ".29 MB\n"
-            )
-            )
+            ))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ import django.test
 from django.contrib.gis.geos import GEOSGeometry
 
 import geospaas_processing.copiers
-import geospaas_processing.cli.copy as cli_copy
+import geospaas_processing.cli.delete_and_copy as cli_copy
 import geospaas_processing.cli.download as cli_download
 import geospaas_processing.cli.util as util
 from geospaas.catalog.models import Dataset

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -310,7 +310,7 @@ class CopyingCLITestCase(django.test.TestCase):
             with tempfile.NamedTemporaryFile(dir=tmpdirname) as tmpfile:
                 os.symlink(src=tmpfile.name, dst=tmpfile.name + '_symlink')  # symlink creation
                 broken_symlink_path = os.path.join(tmpdirname, 'broken_symlink')
-                os.symlink(src=tmpdirname+'/blablablah', dst=broken_symlink_path)
+                os.symlink(src=os.path.join(tmpdirname, 'blablablah'), dst=broken_symlink_path)
                 copier = geospaas_processing.copiers.Copier('type1', tmpdirname)
                 with mock.patch('os.remove') as mock_os_remove:
                     copier.delete(0)


### PR DESCRIPTION
@akorosov @aperrin66 
for the second new test, I mean for `test_deleting_symlinks_without_a_reference_file` it is not possible to work with temporary file. The reason is that the tempfile deals with the deletion of that tempfile inside the context manager in the __exit__ method. We have deleted the file in the middle of the test and this causes problem for that __exit__ method of tempfile to work properly. I use a normal file with `touch` instead. This second test is also in temporary directory, so it does not cause any problem and there is no need to change it in this regard.