### PR TITLE
Update delete_and_copy.py

### DIFF
--- a/geospaas_processing/cli/delete_and_copy.py
+++ b/geospaas_processing/cli/delete_and_copy.py
@@ -40,7 +40,7 @@ def cli_parse_args():
         '-t', '--type', required=False, type=str,
         help="The type of dataset (as a str) which is written in flag file for further processing.")
     parser.add_argument(
-        '-ttl', '--time_to_live', required=False, type=str, default="90",
+        '-ttl', '--time_to_live', required=True, type=str, default="90",
         help="The upper limit [in days] of file existence that have already been copied."
         + " If the file is older than this limit, it will be deleted.")
     return parser.parse_args()


### PR DESCRIPTION
@akorosov @aperrin66 based on the new design of lacking the --keep_permanently, ttl must be provided as input anytime when using delete_and_copy cli