### PR TITLE
Enable OAuth2 authentication + !ENV tags in provider settings

### DIFF
--- a/Dockerfile_cli
+++ b/Dockerfile_cli
@@ -1,6 +1,11 @@
 ARG BASE_IMAGE=nansencenter/geospaas:latest-slim
 FROM ${BASE_IMAGE} AS base
-RUN pip install --no-cache-dir django-celery-results==1.2 redis==3.5.3 graypy==2.1.0 freezegun==1.1.0
+RUN pip install --no-cache-dir \
+    django-celery-results==1.2 \
+    freezegun==1.1.0 \
+    graypy==2.1.0 \
+    redis==3.5.3 \
+    requests_oauthlib==1.3
 
 WORKDIR /tmp/setup
 COPY setup.py README.md ./

--- a/Dockerfile_worker
+++ b/Dockerfile_worker
@@ -7,6 +7,7 @@ RUN pip install --no-cache-dir \
     graypy==2.1.0 \
     paramiko==2.7.2 \
     redis==3.5 \
+    requests_oauthlib==1.3 \
     scp==0.13.2 \
     freezegun==1.1.0
 

--- a/README.md
+++ b/README.md
@@ -102,19 +102,24 @@ It is a YAML file with the following structure:
 ```yaml
 ---
 '<provider_url_prefix>':
-  username: '<username>'
-  password_env_var: '<password_env_var>'
+  property1: 'value1'
+  property2: 'value2'
 '<provider2_url_prefix>':
-  username2: '<username2>'
-  password_env_var2: '<password_env_var2>'
+  property1: 'value1'
+  property3: 'value3'
 ...
 ```
 
-Where:
-  - `<provider_url_prefix>` is the prefix of the URL for a given provider. Download URLs are matched
-    against it to find the provider for a given URL.
-  - `<username>`: is the user name to use as a string
-  - `<password_env_var>`: is the name of an environment variable containing the password
+The provider prefixes will be matched against the URI of the dataset to determine which settings
+apply. The available settings are the following:
+  - `username`: the user name
+  - `password`: the password
+  - `max_parallel_downloads`: the maximum number of downloads which can run simultaneously
+    for a provider
+  - `authentication_type`: for providers which do not use basic authentication, it is possible to
+    specify an alternative authentication type. For now, only OAuth2 is supported.
+  - `token_url`: for OAuth2, the URL where tokens can be retrieved
+  - `client_id`: for OAuth2, the client ID to use
 
 #### Enabling limits on the number of parallel downloads
 

--- a/geospaas_processing/provider_settings.yml
+++ b/geospaas_processing/provider_settings.yml
@@ -12,8 +12,8 @@
   username: 'anonymous'
   password_env_var: ''
 'ftp://ftp.gportal.jaxa.jp':
-  username: topvoys
-  password_env_var: 'JAXA_PASSWORD'
+  username: !ENV 'JAXA_USERNAME'
+  password: !ENV 'JAXA_PASSWORD'
 'https://zipper.creodias.eu':
   username: !ENV 'CREODIAS_USERNAME'
   password: !ENV 'CREODIAS_PASSWORD'

--- a/geospaas_processing/provider_settings.yml
+++ b/geospaas_processing/provider_settings.yml
@@ -1,12 +1,12 @@
 ---
 # Dictionary associating URLs to settings to pass to the downloaders
 'https://scihub.copernicus.eu':
-  username: 'topvoys'
-  password_env_var: 'COPERNICUS_OPEN_HUB_PASSWORD'
+  username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
+  password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
   max_parallel_downloads: 2
 'ftp://nrt.cmems-du.eu':
-  username: 'tnersc'
-  password_env_var: 'CMEMS_PASSWORD'
+  username: !ENV 'CMEMS_USERNAME'
+  password: !ENV 'CMEMS_PASSWORD'
   max_parallel_downloads: 10
 'ftp://anon-ftp.ceda.ac.uk':
   username: 'anonymous'
@@ -15,8 +15,8 @@
   username: topvoys
   password_env_var: 'JAXA_PASSWORD'
 'https://zipper.creodias.eu':
-  username: 'nerscci@outlook.com'
-  password_env_var: 'CREODIAS_PASSWORD'
+  username: !ENV 'CREODIAS_USERNAME'
+  password: !ENV 'CREODIAS_PASSWORD'
   authentication_type: 'oauth2'
   token_url: 'https://auth.creodias.eu/auth/realms/DIAS/protocol/openid-connect/token'
   client_id: 'CLOUDFERRO_PUBLIC'

--- a/geospaas_processing/provider_settings.yml
+++ b/geospaas_processing/provider_settings.yml
@@ -7,10 +7,18 @@
 'ftp://nrt.cmems-du.eu':
   username: 'tnersc'
   password_env_var: 'CMEMS_PASSWORD'
+  max_parallel_downloads: 10
 'ftp://anon-ftp.ceda.ac.uk':
   username: 'anonymous'
   password_env_var: ''
 'ftp://ftp.gportal.jaxa.jp':
   username: topvoys
   password_env_var: 'JAXA_PASSWORD'
+'https://zipper.creodias.eu':
+  username: 'nerscci@outlook.com'
+  password_env_var: 'CREODIAS_PASSWORD'
+  authentication_type: 'oauth2'
+  token_url: 'https://auth.creodias.eu/auth/realms/DIAS/protocol/openid-connect/token'
+  client_id: 'CLOUDFERRO_PUBLIC'
+  max_parallel_downloads: 1
 ...

--- a/geospaas_processing/provider_settings.yml
+++ b/geospaas_processing/provider_settings.yml
@@ -10,7 +10,8 @@
   max_parallel_downloads: 10
 'ftp://anon-ftp.ceda.ac.uk':
   username: 'anonymous'
-  password_env_var: ''
+  password: ''
+  max_parallel_downloads: 12
 'ftp://ftp.gportal.jaxa.jp':
   username: !ENV 'JAXA_USERNAME'
   password: !ENV 'JAXA_PASSWORD'

--- a/geospaas_processing/utils.py
+++ b/geospaas_processing/utils.py
@@ -7,6 +7,7 @@ import shutil
 import stat
 import tarfile
 import time
+import yaml
 import zipfile
 from contextlib import contextmanager
 
@@ -320,3 +321,12 @@ def tar_gzip(file_path):
         with tarfile.open(archive_path, 'w:gz') as archive:
             archive.add(file_path, arcname=os.path.basename(file_path))
     return archive_path
+
+
+def yaml_env_safe_load(stream):
+    """Parses a YAML string with support for the !ENV tag.
+    A string tagged with !ENV is replaced by the value of the
+    environment variable whose name is that string.
+    """
+    yaml.SafeLoader.add_constructor('!ENV', lambda loader, node: os.getenv(node.value))
+    return yaml.safe_load(stream)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setuptools.setup(
         "Operating System :: POSIX :: Linux",
     ],
     python_requires='>=3.7',
-    install_requires=['django-geo-spaas', 'paramiko', 'scp'],
+    install_requires=['django-geo-spaas', 'paramiko', 'scp', 'requests', 'requests_oauthlib'],
     package_data={'': ['*.yml', 'auxiliary/*', 'auxiliary/*/*', 'parameters/*']},
 )

--- a/tests/data/provider_settings.yml
+++ b/tests/data/provider_settings.yml
@@ -2,8 +2,8 @@
 # Provider settings for unit tests
 # Dictionary associating URLs to settings to pass to the downloaders
 'https://scihub.copernicus.eu':
-  username: 'topvoys'
-  password_env_var: 'COPERNICUS_OPEN_HUB_PASSWORD'
+  username: !ENV 'COPERNICUS_OPEN_HUB_USERNAME'
+  password: !ENV 'COPERNICUS_OPEN_HUB_PASSWORD'
   max_parallel_downloads: 2
 'https://random.url':
   max_parallel_downloads: 10

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -11,12 +11,13 @@ import unittest.mock as mock
 from pathlib import Path
 
 import django.test
+import requests
+from geospaas.catalog.managers import LOCAL_FILE_SERVICE
+from geospaas.catalog.models import Dataset
+from redis import Redis
+
 import geospaas_processing.downloaders as downloaders
 import geospaas_processing.utils as utils
-import requests
-from geospaas.catalog.models import Dataset
-from geospaas.catalog.managers import LOCAL_FILE_SERVICE
-from redis import Redis
 
 
 class DownloaderTestCase(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -419,7 +419,10 @@ class RemoteStorageTestCase(unittest.TestCase):
         mock.patch('paramiko.SSHClient').start()
         with mock.patch.object(utils.RemoteStorage, 'get_block_size', return_value=4096):
             self.storage = utils.RemoteStorage(host='server', path='/foo/bar/')
-        self.addCleanup(mock.patch.stopall)
+
+    def tearDown(self):
+        self.storage = None
+        mock.patch.stopall()
 
     def test_remote_storage_destructor(self):
         """The SSH connection should be closed when a RemoteStorage object is destroyed"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,6 +100,21 @@ class UtilsTestCase(unittest.TestCase):
             self.assertEqual(result, archive_file_path)
             mock_add.assert_not_called()
 
+    def test_yaml_env_safe_load(self):
+        """yaml_env_safe_load() should return the same as result of
+        yaml.safe_load(), except !ENV tagged values are replaced with
+        the contents of the corresponding environment variable.
+        """
+        yaml_string = '''---
+        var1: !ENV foo
+        var2: baz
+        '''
+        with mock.patch('os.environ', {'foo': 'bar'}):
+            self.assertDictEqual(
+                utils.yaml_env_safe_load(yaml_string),
+                {'var1': 'bar', 'var2': 'baz'}
+            )
+
 
 class AbstractStorageMethodsTestCase(unittest.TestCase):
     """Tests for the abstract methods of the base Storage class"""


### PR DESCRIPTION
Resolves #43 
The HTTP downloader now support OAuth2 authentication.

I also added support for `!ENV` tags in provider_settings.yml in order to manage credentials more cleanly and flexibly.