### PR TITLE
Fix scihub concurrent download

### DIFF
--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -109,35 +109,35 @@ class Downloader():
         auth = cls.get_auth(kwargs)
         connection = cls.connect(url, auth)
 
-        file_name = cls.get_file_name(url, connection)
-        if not file_name:
-            raise DownloadError(f"Could not find file name for '{url}'")
-        file_path = os.path.join(download_dir, file_name)
-
-        if os.path.exists(file_path) and os.path.isfile(file_path):
-            return file_name, False
-
-        file_size = cls.get_file_size(url, connection)
-        if file_size:
-            LOGGER.debug("Checking there is enough free space to download %s bytes", file_size)
-            utils.LocalStorage(path=download_dir).free_space(file_size)
-
         try:
-            with open(file_path, 'wb') as target_file:
-                cls.download_file(target_file, url, connection)
-        except OSError as error:
-            if error.errno == errno.ENOSPC:
-                # In case of "No space left on device" error,
-                # try to remove the partially downloaded file
-                try:
-                    os.remove(file_path)
-                except FileNotFoundError:
-                    pass
-            raise
+            file_name = cls.get_file_name(url, connection)
+            if not file_name:
+                raise DownloadError(f"Could not find file name for '{url}'")
+            file_path = os.path.join(download_dir, file_name)
+
+            if os.path.exists(file_path) and os.path.isfile(file_path):
+                return file_name, False
+
+            file_size = cls.get_file_size(url, connection)
+            if file_size:
+                LOGGER.debug("Checking there is enough free space to download %s bytes", file_size)
+                utils.LocalStorage(path=download_dir).free_space(file_size)
+
+            try:
+                with open(file_path, 'wb') as target_file:
+                    cls.download_file(target_file, url, connection)
+            except OSError as error:
+                if error.errno == errno.ENOSPC:
+                    # In case of "No space left on device" error,
+                    # try to remove the partially downloaded file
+                    try:
+                        os.remove(file_path)
+                    except FileNotFoundError:
+                        pass
+                raise
+            return file_name, True
         finally:
             cls.close_connection(connection)
-
-        return file_name, True
 
 
 class HTTPDownloader(Downloader):

--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -262,7 +262,7 @@ class FTPDownloader(Downloader):
         try:
             return ftplib.FTP(host=urlparse(url).netloc, user=auth[0], passwd=auth[1])
         except ftplib.all_errors as error:
-            raise DownloadError(f"Could not download from '{url}'") from error
+            raise DownloadError(f"Could not download from '{url}': {error.args}") from error
 
     @classmethod
     def get_file_name(cls, url, connection):

--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -206,8 +206,16 @@ class HTTPDownloader(Downloader):
             response = requests.get(url, stream=True, auth=auth)
             response.raise_for_status()
         # Raising DownloadError enables to display a clear message in the API response
+        except requests.HTTPError as error:
+            details = f"{response.status_code} {response.text}"
+            response.close()
+            raise DownloadError(
+                f"Could not download from '{url}'; response: {details}"
+            ) from error
         except requests.RequestException as error:
-            raise DownloadError(f"Could not download from '{url}'") from error
+            raise DownloadError(
+                f"Could not download from '{url}'"
+            ) from error
 
         return response
 

--- a/geospaas_processing/provider_settings.yml
+++ b/geospaas_processing/provider_settings.yml
@@ -12,6 +12,10 @@
   username: 'anonymous'
   password: ''
   max_parallel_downloads: 12
+'ftp://ftp.ceda.ac.uk':
+  username: !ENV 'CEDA_USERNAME'
+  password: !ENV 'CEDA_PASSWORD'
+  max_parallel_downloads: 10
 'ftp://ftp.gportal.jaxa.jp':
   username: !ENV 'JAXA_USERNAME'
   password: !ENV 'JAXA_PASSWORD'

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -273,10 +273,20 @@ class HTTPDownloaderTestCase(unittest.TestCase):
         self.assertIsInstance(error.exception.__cause__, requests.HTTPError)
 
     def test_connect_request_exception(self):
-        """An exception must be raised if an error happens during the
-        request (it can be a wrong HTTP response code)
+        """An exception must be raised if an error prevents the
+        connection from happening
         """
-        with mock.patch('requests.get', side_effect=requests.HTTPError):
+        with mock.patch('requests.get', side_effect=requests.ConnectionError):
+            with self.assertRaises(downloaders.DownloadError):
+                downloaders.HTTPDownloader.connect('url')
+
+    def test_connect_request_http_exception(self):
+        """An exception must be raised if an HTTP error is returned by
+        the remote server
+        """
+        mock_response = mock.Mock()
+        with mock.patch('requests.get', return_value=mock_response):
+            mock_response.raise_for_status.side_effect = requests.HTTPError
             with self.assertRaises(downloaders.DownloadError):
                 downloaders.HTTPDownloader.connect('url')
 


### PR DESCRIPTION
- Use a HEAD request to get the file name for the HTTP downloader.
  This avoids problems with the stream connection not closing when a file already exists.
- Make sure that connections are always closed.
- Make error messages clearer.