### PR TITLE
Remove corrupted downloaded files

### DIFF
--- a/geospaas_processing/converters.py
+++ b/geospaas_processing/converters.py
@@ -108,7 +108,17 @@ class IDFConversionManager():
         file_path = os.path.join(self.working_directory, file_name)
 
         # Unzip the file if necessary
-        extract_dir = utils.unarchive(file_path)
+        try:
+            extract_dir = utils.unarchive(file_path)
+        except shutil.ReadError as error:
+            try:
+                os.remove(file_path)
+            except IsADirectoryError:
+                shutil.rmtree(file_path)
+            raise ConversionError(
+                "The input archive was corrupted." +
+                " It has been removed, you can try to download the file again") from error
+
         if extract_dir:
             # Set the extracted file as the path to convert
             file_path = os.path.join(extract_dir, os.listdir(extract_dir)[0])

--- a/geospaas_processing/utils.py
+++ b/geospaas_processing/utils.py
@@ -359,7 +359,11 @@ def unarchive(in_file):
         extract_dir = match.group(1)
         os.makedirs(extract_dir, exist_ok=True)
 
-        shutil.unpack_archive(in_file, extract_dir)
+        try:
+            shutil.unpack_archive(in_file, extract_dir)
+        except shutil.ReadError:
+            shutil.rmtree(extract_dir)
+            raise
 
     return extract_dir
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -215,6 +215,17 @@ class IDFConversionManagerTestCase(django.test.TestCase):
                     callable(matching_function),
                     f"In {converter_class}, {matching_function} should be a function")
 
+    def test_remove_corrupted_archive(self):
+        """If a conversion fails because of a corrupt archive, it
+        should be removed
+        """
+        corrupt_archive = self.temp_dir_path / 'corrupt_archive.zip'
+        corrupt_archive.touch()
+        with self.assertRaises(converters.ConversionError) as error:
+            self.conversion_manager.convert(1, corrupt_archive.name)
+            self.assertIn('The input archive was corrupted', str(error.exception))
+        self.assertFalse(os.path.exists(corrupt_archive))
+
 
 class IDFConverterTestCase(unittest.TestCase):
     """Tests for the base IDFConverter class"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 import unittest.mock as mock
 from contextlib import contextmanager
+from pathlib import Path
 
 import geospaas_processing.utils as utils
 
@@ -127,6 +128,19 @@ class ArchiveUtilsTestCase(unittest.TestCase):
                     f"{unpacked_file} is not a file (unpacking {file})")
                 with open(unpacked_file, 'r') as f_h:
                     self.assertEqual(f_h.read(), 'hello\n')
+
+    def test_unarchive_removes_corrupt_extraction_dir(self):
+        """`unarchive()` should remove the extraction directory in case
+        of corrupt file
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir_path = Path(tmp_dir)
+            corrup_archive_name = 'corrupt_archive'
+            corrupt_archive = tmp_dir_path / f"{corrup_archive_name}.tgz"
+            corrupt_archive.touch()
+            with self.assertRaises(shutil.ReadError):
+                utils.unarchive(str(corrupt_archive))
+            self.assertFalse(os.path.exists(tmp_dir_path / corrup_archive_name))
 
 
 class AbstractStorageMethodsTestCase(unittest.TestCase):


### PR DESCRIPTION
Fix for #67, while waiting for a better solution.

When we get an error due to a corrupted file, we remove it so that the download can be retried without having to manually remove the problematic file.

This fix is currently used for TOPVOYS.