### PR TITLE
Hotfix

### DIFF
--- a/geospaas_processing/converters/syntool/converter.py
+++ b/geospaas_processing/converters/syntool/converter.py
@@ -263,7 +263,7 @@ class Sentinel1SyntoolConverter(BasicSyntoolConverter):
                     final_result_path = result_dir.parent.parent / result_dir.name
                     shutil.rmtree(final_result_path, ignore_errors=True)
                     result_dir.replace(final_result_path)
-                    results.append(str(final_result_path))
+                    results.append(str(final_result_path.relative_to(out_dir)))
                 base_result_path.rmdir()
         os.rmdir(in_file)
         return results

--- a/geospaas_processing/tasks/core.py
+++ b/geospaas_processing/tasks/core.py
@@ -102,7 +102,7 @@ def unarchive(self, args):  # pylint: disable=unused-argument
                 " It has been removed, you can try to download the file again") from error
         if extract_dir:
             extracted_files = os.listdir(extract_dir)
-            extract_dir_name = os.path.basename(extract_dir)
+            extract_dir_name = os.path.relpath(extract_dir, WORKING_DIRECTORY)
             results.extend([os.path.join(extract_dir_name, f) for f in extracted_files])
         else:
             results.append(file)

--- a/geospaas_processing/tasks/syntool.py
+++ b/geospaas_processing/tasks/syntool.py
@@ -50,6 +50,7 @@ def check_ingested(self, args, **kwargs):
     if ingested_files.exists():
         logger.info("Already produced syntool files for dataset %s, stopping.", dataset_id)
         self.request.callbacks = None
+        self.request.chain = None
         return (dataset_id, [i.path for i in ingested_files])
     return args
 


### PR DESCRIPTION
- have the `unarchive()` task return the right path
- make `check_ingested()` work with task chains, not just callbacks
- minor fix for Sentinel 1 Syntool converter: return relative paths