### PR TITLE
Various fixes

### DIFF
--- a/geospaas_processing/celeryconfig.py
+++ b/geospaas_processing/celeryconfig.py
@@ -1,0 +1,15 @@
+""" Celery settings"""
+import os
+
+
+broker_url = os.getenv(
+    'GEOSPAAS_PROCESSING_BROKER', 'amqp://guest:guest@localhost:5672')
+result_backend = 'django-db'
+accept_content = ['json', 'pickle']
+task_routes = {
+    'geospaas_processing.tasks.core.*': {'queue': 'core'},
+    'geospaas_processing.tasks.idf.*': {'queue': 'idf'},
+    'geospaas_processing.tasks.syntool.*': {'queue': 'syntool'},
+    'geospaas_processing.tasks.harvesting.*': {'queue': 'harvesting'},
+}
+worker_prefetch_multiplier = '1'

--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -595,10 +595,11 @@ class DownloadManager():
         """Remove downloaded dataset files"""
         removed = []
         for dataset in self.datasets:
+            relative_download_dir = self.get_dataset_directory(dataset)
             download_dir = os.path.join(
                 self.download_folder,
-                self.get_dataset_directory(dataset))
+                relative_download_dir)
             if os.path.isdir(download_dir):
                 shutil.rmtree(download_dir, ignore_errors=True)
-                removed.append(download_dir)
+                removed.append(relative_download_dir)
         return removed

--- a/geospaas_processing/settings.py
+++ b/geospaas_processing/settings.py
@@ -35,20 +35,6 @@ django_settings = {
     'USE_L10N': True,
     'USE_TZ': True,
     'DEFAULT_AUTO_FIELD': 'django.db.models.AutoField',
-    # Celery settings
-    'CELERY_BROKER_URL': os.getenv(
-        'GEOSPAAS_PROCESSING_BROKER', 'amqp://guest:guest@localhost:5672'),
-    'CELERY_RESULT_BACKEND': 'django-db',
-    # syntool conversion needs to be processed by a specific worker
-    # with the right tools installed
-    'CELERY_ACCEPT_CONTENT': ['json', 'pickle'],
-    'CELERY_TASK_ROUTES': {
-        'geospaas_processing.tasks.core.*': {'queue': 'core'},
-        'geospaas_processing.tasks.idf.*': {'queue': 'idf'},
-        'geospaas_processing.tasks.syntool.*': {'queue': 'syntool'},
-        'geospaas_processing.tasks.harvesting.*': {'queue': 'harvesting'},
-    },
-    'CELERYD_PREFETCH_MULTIPLIER': 1,
 }
 
 if django_celery_results:

--- a/geospaas_processing/tasks/__init__.py
+++ b/geospaas_processing/tasks/__init__.py
@@ -24,7 +24,7 @@ WORKING_DIRECTORY = os.getenv('GEOSPAAS_PROCESSING_WORK_DIR', '/tmp/test_data')
 DATASET_LOCK_PREFIX = 'lock-'
 
 app = celery.Celery('geospaas_processing')
-app.config_from_object('django.conf:settings', namespace='CELERY')
+app.config_from_object('geospaas_processing.celeryconfig')
 
 
 @celery.signals.after_setup_logger.connect

--- a/geospaas_processing/tasks/__init__.py
+++ b/geospaas_processing/tasks/__init__.py
@@ -58,14 +58,14 @@ def lock_dataset_files(function):
         retries_count = 60
         task = args[0]
         if 'args' in kwargs:
-            task_args = kwargs['args']
+            task_args = kwargs.pop('args')
         else:
             task_args = args[1]
         dataset_id = task_args[0]
         lock_id = f"{DATASET_LOCK_PREFIX}{dataset_id}"
         with utils.redis_lock(lock_id, task.request.id or 'local') as acquired:
             if acquired:
-                return function(*args, **kwargs)
+                return function(task, task_args, **kwargs)
             else:
                 logger_.info("Another task is in progress on dataset %s, retrying", dataset_id)
                 task.retry((task_args,), countdown=retries_wait, max_retries=retries_count)

--- a/geospaas_processing/tasks/core.py
+++ b/geospaas_processing/tasks/core.py
@@ -14,11 +14,10 @@ import geospaas_processing.utils as utils
 from geospaas_processing.tasks import lock_dataset_files, FaultTolerantTask, WORKING_DIRECTORY
 from ..downloaders import DownloadManager, TooManyDownloadsError
 
+from . import app
+
 
 logger = celery.utils.log.get_task_logger(__name__)
-
-app = celery.Celery(__name__)
-app.config_from_object('django.conf:settings', namespace='CELERY')
 
 
 @app.task(base=FaultTolerantTask, bind=True, track_started=True)

--- a/geospaas_processing/tasks/harvesting.py
+++ b/geospaas_processing/tasks/harvesting.py
@@ -7,12 +7,12 @@ import celery.utils
 
 from geospaas_harvesting.cli import refresh_vocabularies, retry_ingest
 from geospaas_harvesting.config import ProvidersConfiguration, SearchConfiguration
+
 from geospaas_processing.tasks import FaultTolerantTask
+from . import app
 
 
 logger = celery.utils.log.get_task_logger(__name__)
-app = celery.Celery(__name__)
-app.config_from_object('django.conf:settings', namespace='CELERY')
 
 
 HARVEST_CONFIG_PATH = os.getenv('GEOSPAAS_PROCESSING_HARVEST_CONFIG')

--- a/geospaas_processing/tasks/idf.py
+++ b/geospaas_processing/tasks/idf.py
@@ -3,12 +3,10 @@ import celery
 
 from geospaas_processing.tasks import lock_dataset_files, FaultTolerantTask, WORKING_DIRECTORY
 from ..converters.idf.converter import IDFConversionManager
+from . import app
 
 
 logger = celery.utils.log.get_task_logger(__name__)
-
-app = celery.Celery(__name__)
-app.config_from_object('django.conf:settings', namespace='CELERY')
 
 
 @app.task(base=FaultTolerantTask, bind=True, track_started=True)

--- a/geospaas_processing/tasks/syntool.py
+++ b/geospaas_processing/tasks/syntool.py
@@ -11,12 +11,9 @@ from geospaas.catalog.models import Dataset
 from geospaas_processing.tasks import lock_dataset_files, FaultTolerantTask, WORKING_DIRECTORY
 from ..converters.syntool.converter import SyntoolConversionManager
 from ..models import ProcessingResult
-
+from . import app
 
 logger = celery.utils.log.get_task_logger(__name__)
-
-app = celery.Celery(__name__)
-app.config_from_object('django.conf:settings', namespace='CELERY')
 
 
 def get_db_config():


### PR DESCRIPTION
- move celery configuration to its own file
- have all task modules use the same app instead of parsing the configuration separately
- make the method which removes downloaded files return relative paths
- fix the lock_dataset_files decorator
- main change: check_ingested() takes as argument the signature to execute if the files are not here.
  This avoids breaking chain results when the files are already there