### PR TITLE
Parameterize provider settings

### DIFF
--- a/geospaas_processing/tasks/__init__.py
+++ b/geospaas_processing/tasks/__init__.py
@@ -21,6 +21,7 @@ import geospaas_processing.utils as utils
 
 logger_ = celery.utils.log.get_task_logger(__name__)
 WORKING_DIRECTORY = os.getenv('GEOSPAAS_PROCESSING_WORK_DIR', '/tmp/test_data')
+PROVIDER_SETTINGS_PATH = os.getenv('GEOSPAAS_PROCESSING_PROVIDER_SETTINGS_PATH', None)
 DATASET_LOCK_PREFIX = 'lock-'
 
 app = celery.Celery('geospaas_processing')

--- a/geospaas_processing/tasks/core.py
+++ b/geospaas_processing/tasks/core.py
@@ -11,7 +11,10 @@ import celery.utils
 
 import geospaas_processing.ops as ops
 import geospaas_processing.utils as utils
-from geospaas_processing.tasks import lock_dataset_files, FaultTolerantTask, WORKING_DIRECTORY
+from geospaas_processing.tasks import (lock_dataset_files,
+                                       FaultTolerantTask,
+                                       WORKING_DIRECTORY,
+                                       PROVIDER_SETTINGS_PATH)
 from ..downloaders import DownloadManager, TooManyDownloadsError
 
 from . import app
@@ -27,6 +30,7 @@ def download(self, args):
     dataset_id = args[0]
     download_manager = DownloadManager(
         download_directory=WORKING_DIRECTORY,
+        provider_settings_path=PROVIDER_SETTINGS_PATH,
         pk=dataset_id
     )
     try:
@@ -54,6 +58,7 @@ def remove_downloaded(self, args):  # pylint: disable=unused-argument
     dataset_id = args[0]
     download_manager = DownloadManager(
         download_directory=WORKING_DIRECTORY,
+        provider_settings_path=PROVIDER_SETTINGS_PATH,
         pk=dataset_id
     )
     return (dataset_id, download_manager.remove())

--- a/tests/tasks/test_core_tasks.py
+++ b/tests/tasks/test_core_tasks.py
@@ -69,6 +69,7 @@ class DownloadTestCase(unittest.TestCase):
         """Test removing downloaded files"""
         tasks_core.remove_downloaded((1,))
         self.dm_mock.assert_called_with(download_directory=tasks_core.WORKING_DIRECTORY,
+                                        provider_settings_path=None,
                                         pk=1)
         self.dm_mock.return_value.remove.assert_called_once()
 


### PR DESCRIPTION
Allow setting the `provider_settings.yml` file path through an environment variable.