### PR TITLE
Handle "Stale file handle" on Syntool cleanup

### DIFF
--- a/geospaas_processing/tasks/syntool.py
+++ b/geospaas_processing/tasks/syntool.py
@@ -137,8 +137,10 @@ def cleanup(self, criteria):
                 shutil.rmtree(result_path)
             except NotADirectoryError:
                 os.remove(result_path)
-        except FileNotFoundError:
-            logger.warning("%s has already been deleted", result_path)
+        except (FileNotFoundError, OSError) as error:
+            if (isinstance(error, FileNotFoundError) or
+                    (isinstance(error, OSError) and error.errno == 116)):
+                logger.warning("%s has already been deleted", result_path, exc_info=True)
 
         # remove the entry from the syntool database
         match = re.search(

--- a/tests/tasks/test_syntool_tasks.py
+++ b/tests/tasks/test_syntool_tasks.py
@@ -184,6 +184,14 @@ class CleanupIngestedTestCase(django.test.TestCase):
         with self.assertLogs(tasks_syntool.logger, level=logging.WARNING):
             self.assertListEqual(tasks_syntool.cleanup({'id': 1}), [expected_path])
 
+    def test_cleanup_stale_file_handle(self):
+        """Test behavior when a stale file handle error happens
+        """
+        self.mock_rmtree.side_effect = OSError(116, '[Errno 116] Stale file handle')
+        expected_path = 'ingested/product_name/granule_name/'  # see fixture
+        with self.assertLogs(tasks_syntool.logger, level=logging.WARNING):
+            self.assertListEqual(tasks_syntool.cleanup({'id': 1}), [expected_path])
+
     def test_cleanup_file_subprocess_error(self):
         """Test behavior when an error occurs running the mysql command
         """


### PR DESCRIPTION
Catch the "stale file handle" error that sometimes happens during Syntool cleanup.