### PR TITLE
Add necessary metadata to data_access feature in syntool conversions

### DIFF
--- a/geospaas_processing/converters/syntool/converter.py
+++ b/geospaas_processing/converters/syntool/converter.py
@@ -93,6 +93,7 @@ class SyntoolConverter(Converter):
         """
         dataset = kwargs['dataset']
         config = configparser.ConfigParser()
+        config['metadata'] = {'syntool_id': 'data_access'}
         config['geospaas'] = {
             'entry_id': dataset.entry_id,
             'dataset_url': self._extract_url(dataset),

--- a/tests/converters/test_syntool_converters.py
+++ b/tests/converters/test_syntool_converters.py
@@ -100,6 +100,9 @@ class SyntoolConverterTestCase(unittest.TestCase):
             self.assertEqual(
                 contents,
                 textwrap.dedent("""\
+                [metadata]
+                syntool_id = data_access
+
                 [geospaas]
                 entry_id = foo
                 dataset_url = https://bar


### PR DESCRIPTION
Fix missing metadata from the `features/data_access.ini` file generated during a Syntool conversion.