### PR TITLE
Stop using MANIFEST.in for data files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-recursive-include geospaas_processing **.yml
-include geospaas_processing/converters/*/parameters/*
-recursive-include geospaas_processing/converters/*/extra_readers **
-prune **/__pycache__/**
-global-exclude **.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,12 @@ idf = ['idf_converter']
 
 [tool.setuptools.packages.find]
 include = ["geospaas_processing*"]
+
+[tool.setuptools.package-data]
+'geospaas_processing' = [
+    '*.yml',
+    'converters/*/parameters/*',
+    'converters/*/extra_readers/*.py',
+    'converters/*/extra_readers/resources/*',
+    'converters/*/extra_readers/resources/*/*',
+]


### PR DESCRIPTION
It does not preserve permissions (which is needed for the `runner.py` script for Syntool conversion using extra readers)