### PR TITLE
Fix broken execute permissions in wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
              docker run --rm
              -v "$(pwd):/src"
              "${{ vars.DOCKER_ORG }}/geospaas:latest"
-             bash -c "pip install build && python -m build"
+             bash -c "pip install build && python -m build -s -w"
 
       - name: 'Deploy package to the Github release'
         env:


### PR DESCRIPTION
Add -s -w options to build command.
This avoids problems with data files permissions in the generated wheel for some reason.