### PR TITLE
Fix converter options

### DIFF
--- a/geospaas_processing/converters/syntool/converter.py
+++ b/geospaas_processing/converters/syntool/converter.py
@@ -121,7 +121,7 @@ class BasicSyntoolConverter(SyntoolConverter):
         ParameterSelector(
             matches=lambda d: re.match(r'^S3[AB]_OL_2_WFR.*$', d.entry_id),
             converter_type='sentinel3_olci_l2',
-            convert_options={'channels': 'CHL_OC4ME'},
+            converter_options={'channels': 'CHL_OC4ME'},
             ingest_parameter_files='ingest_geotiff_4326_tiles'),
         ParameterSelector(
             matches=lambda d: re.match(r'^S3[AB]_SL_1_RBT.*$', d.entry_id),
@@ -174,7 +174,7 @@ class BasicSyntoolConverter(SyntoolConverter):
         ParameterSelector(
             matches=lambda d: '-REMSS-L4_GHRSST-SSTfnd-MW_OI-GLOB-' in d.entry_id,
             converter_type='remss_l4_mw_sst',
-            convert_options={'vmin_pal': '273', 'vmax_pal': '298'},
+            converter_options={'vmin_pal': '273', 'vmax_pal': '298'},
             ingest_parameter_files='ingest_geotiff_4326_raster_no_shape'),
     )
 

--- a/geospaas_processing/converters/syntool/converter.py
+++ b/geospaas_processing/converters/syntool/converter.py
@@ -218,10 +218,10 @@ class BasicSyntoolConverter(SyntoolConverter):
         and in the keyword arguments into a list ready to be passed to
         the conversion command
         """
-        converter_options = kwargs.pop('converter_options', {})
+        converter_options = self.converter_options.copy()
         converter_options_list = []
         if self.converter_options:
-            converter_options.update(self.converter_options)
+            converter_options.update(kwargs.pop('converter_options', {}))
         if converter_options:
             converter_options_list.append('-opt')
             for key, value in converter_options.items():

--- a/geospaas_processing/converters/syntool/converter.py
+++ b/geospaas_processing/converters/syntool/converter.py
@@ -180,7 +180,7 @@ class BasicSyntoolConverter(SyntoolConverter):
 
     def __init__(self, **kwargs):
         self.converter_type = kwargs.pop('converter_type')
-        self.converter_options = kwargs.pop('converter_options', None)
+        self.converter_options = kwargs.pop('converter_options', {})
         # Should be a string or list of ParameterSelectors
         self.ingest_parameter_files = kwargs.pop('ingest_parameter_files')
         super().__init__(**kwargs)
@@ -220,8 +220,7 @@ class BasicSyntoolConverter(SyntoolConverter):
         """
         converter_options = self.converter_options.copy()
         converter_options_list = []
-        if self.converter_options:
-            converter_options.update(kwargs.pop('converter_options', {}))
+        converter_options.update(kwargs.pop('converter_options', {}))
         if converter_options:
             converter_options_list.append('-opt')
             for key, value in converter_options.items():

--- a/tests/converters/test_syntool_converters.py
+++ b/tests/converters/test_syntool_converters.py
@@ -173,7 +173,7 @@ class BasicSyntoolConverterTestCase(unittest.TestCase):
         result = converter.parse_converter_options({
             'converter_options': {'quux': 'corge'}
         })
-        self.assertListEqual(result, ['-opt', 'quux=corge', 'bar=baz'])
+        self.assertListEqual(result, ['-opt', 'bar=baz', 'quux=corge'])
 
     def test_parse_converter_options_no_default(self):
         """Test parsing converter options when the converter does not
@@ -206,7 +206,7 @@ class BasicSyntoolConverterTestCase(unittest.TestCase):
             ingest_parameter_files='qux')
         self.assertListEqual(
             converter.parse_converter_args({'converter_options': {'ham': 'egg'}}),
-            ['-t', 'foo', '-opt', 'ham=egg', 'bar=baz'])
+            ['-t', 'foo', '-opt', 'bar=baz', 'ham=egg'])
 
     def test_run(self):
         """Test running the conversion and ingestion"""


### PR DESCRIPTION
- make parameters passed to the converter object override default `syntool-converter` options
- fix typo that caused default converter option to be ignored in some syntool converters