### PR TITLE
Fix converter_options parsing

### DIFF
--- a/geospaas_processing/converters/syntool/converter.py
+++ b/geospaas_processing/converters/syntool/converter.py
@@ -220,7 +220,11 @@ class BasicSyntoolConverter(SyntoolConverter):
         """
         converter_options = self.converter_options.copy()
         converter_options_list = []
-        converter_options.update(kwargs.pop('converter_options', {}))
+        kwargs_converter_options = kwargs.pop('converter_options', {})
+        if not isinstance(kwargs_converter_options, dict):
+            logger.warning("'converter_options' should be a dictionary")
+            kwargs_converter_options = {}
+        converter_options.update(kwargs_converter_options)
         if converter_options:
             converter_options_list.append('-opt')
             for key, value in converter_options.items():

--- a/tests/converters/test_syntool_converters.py
+++ b/tests/converters/test_syntool_converters.py
@@ -198,6 +198,18 @@ class BasicSyntoolConverterTestCase(unittest.TestCase):
         result = converter.parse_converter_options({})
         self.assertListEqual(result, ['-opt', 'bar=baz'])
 
+    def test_parse_converter_options_not_dict(self):
+        """Test parsing converter options when the converter_options
+        kwarg is not a dictionary
+        """
+        converter = syntool_converter.BasicSyntoolConverter(
+            converter_type='foo',
+            converter_options={'bar': 'baz'},
+            ingest_parameter_files='qux')
+        with self.assertLogs(level=logging.WARNING):
+            result = converter.parse_converter_options({'converter_options': None})
+        self.assertListEqual(result, ['-opt', 'bar=baz'])
+
     def test_parse_converter_args(self):
         """Test parsing converter arguments"""
         converter = syntool_converter.BasicSyntoolConverter(


### PR DESCRIPTION
Take into account the case when `converter_options` is not a dictionary.