### PR TITLE
fix ecmwf reader palette location

### DIFF
--- a/geospaas_processing/converters/syntool/extra_readers/downscaled_ecmwf_seasonal_forecast.py
+++ b/geospaas_processing/converters/syntool/extra_readers/downscaled_ecmwf_seasonal_forecast.py
@@ -220,7 +220,7 @@ def convert(input_path, output_path):
     }
 
     custom_colortable = read_colortable_from_rgb(
-        os.path.join(os.path.dirname(__file__), 'palettes', 'red_blue.rgb')
+        os.path.join(os.path.dirname(__file__), 'resources', 'palettes', 'red_blue.rgb')
     )
 
     scalar_parameters = (


### PR DESCRIPTION
Fix the location of the palette file for the down-scaled ECMWF forecast Syntool reader.