### PR TITLE
Allow Syntool converter to produce no files

### DIFF
--- a/geospaas_processing/converters/syntool/converter.py
+++ b/geospaas_processing/converters/syntool/converter.py
@@ -50,10 +50,8 @@ class SyntoolConverter(Converter):
                     f"Conversion failed with the following message: {error.stderr}") from error
             results = self.move_results(tmp_dir, out_dir)
         if not results:
-            raise ConversionError((
-                "syntool-converter did not produce any file. "
-                f"stdout: {process.stdout}"
-                f"stderr: {process.stderr}"))
+            logger.warning("syntool-converter did not produce any file.\nstdout: %s\nstderr: %s",
+                           process.stdout,process.stderr)
         return results
 
     def ingest(self, in_file, out_dir, options, **kwargs):

--- a/tests/converters/test_syntool_converters.py
+++ b/tests/converters/test_syntool_converters.py
@@ -45,8 +45,7 @@ class SyntoolConverterTestCase(unittest.TestCase):
         converter = syntool_converter.SyntoolConverter()
         with mock.patch('subprocess.run'), \
              mock.patch.object(converter, 'move_results', return_value=[]):
-            with self.assertLogs(syntool_converter.logger, level=logging.INFO), \
-                 self.assertRaises(converters_base.ConversionError):
+            with self.assertLogs(syntool_converter.logger, level=logging.WARNING):
                 converter.convert('/foo.nc', '/bar', ['--baz'])
 
     def test_ingest(self):


### PR DESCRIPTION
Do not raise exception in case Syntool converters produce no files.
For example, it happens for Sentinel 3 datasets in case of heavy cloud cover.