### PR TITLE
Manage errors for HTTP downloads

### DIFF
--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -410,14 +410,10 @@ class HTTPDownloader(Downloader):
         try:
             for chunk in connection.iter_content(chunk_size=cls.CHUNK_SIZE):
                 file.write(chunk)
-            else:
-                # This executes after the loop and raises an error if the
-                # response is unexpectedly empty like it sometimes happens
-                # with scihub
-                if chunk is None:
-                    raise DownloadError(f"Getting an empty file from '{url}'")
         except requests.exceptions.ChunkedEncodingError as error:
             raise RetriableDownloadError(f"Download from {url} was interrupted") from error
+        if chunk is None:
+            raise DownloadError(f"Getting an empty file from '{url}'")
 
 
 class FTPDownloader(Downloader):

--- a/geospaas_processing/downloaders.py
+++ b/geospaas_processing/downloaders.py
@@ -346,6 +346,8 @@ class HTTPDownloader(Downloader):
                     and url_file_name.endswith('.nc')):
                 return url_file_name
 
+        LOGGER.error("Could not find file name from HTTP response for %s: %s, %s, %s",
+                     url, connection.status_code, connection.reason, connection.headers)
         return ''
 
     @classmethod

--- a/geospaas_processing/tasks/core.py
+++ b/geospaas_processing/tasks/core.py
@@ -15,7 +15,7 @@ from geospaas_processing.tasks import (lock_dataset_files,
                                        FaultTolerantTask,
                                        WORKING_DIRECTORY,
                                        PROVIDER_SETTINGS_PATH)
-from ..downloaders import DownloadManager, TooManyDownloadsError
+from ..downloaders import DownloadManager, RetriableDownloadError, TooManyDownloadsError
 
 from . import app, DATASET_LOCK_PREFIX
 
@@ -38,7 +38,7 @@ def download(self, args):
     except IndexError:
         logger.error("Nothing was downloaded for dataset %s", dataset_id, exc_info=True)
         raise
-    except TooManyDownloadsError:
+    except (TooManyDownloadsError, RetriableDownloadError):
         # Stop retrying after 24 hours
         self.retry((args,), countdown=90, max_retries=960)
     except OSError as error:


### PR DESCRIPTION
Some errors cause HTTP downloads to fail without clear explanation.
For example, failure to find the name of a file