### PR TITLE
Sentinel3 Syntool converter

### DIFF
--- a/geospaas_processing/converters/syntool/converter.py
+++ b/geospaas_processing/converters/syntool/converter.py
@@ -83,7 +83,7 @@ class SyntoolConverter(Converter):
                            process.stdout, process.stderr)
         return results
 
-    def post_ingest(self, results, out_dir, **kwargs):
+    def post_ingest(self, results, out_dir, kwargs):
         """Post-ingestion step, the default is to create a "features"
         directory containing some metadata about what was generated
         """
@@ -235,24 +235,21 @@ class BasicSyntoolConverter(SyntoolConverter):
         converter_args.extend(self.parse_converter_options(kwargs))
         return converter_args
 
-    def run(self, in_file, out_dir, **kwargs):
-        """Transforms a file into a Syntool-displayable format using
-        the syntool-converter and syntool-ingestor tools
-        """
-        results_dir = kwargs.pop('results_dir')
-        # syntool-converter
+    def run_conversion(self, in_file, out_dir, kwargs):
+        """Run the Syntool converter on the input file"""
         if self.converter_type is not None:
             converted_files = self.convert(in_file, out_dir,
                                            self.parse_converter_args(kwargs),
                                            **kwargs)
         else:
             converted_files = (in_file,)
+        return [Path(out_dir, converted_file) for converted_file in converted_files]
 
-        # syntool-ingestor
+    def run_ingestion(self, converted_paths, results_dir, kwargs):
+        """Run the Syntool ingestor on the conversion results"""
         ingestor_config = Path(kwargs.pop('ingestor_config', 'parameters/3413.ini'))
         results = []
-        for converted_file in converted_files:
-            converted_path = Path(out_dir, converted_file)
+        for converted_path in converted_paths:
             for ingest_config in self.find_ingest_config(converted_path):
                 results.extend(self.ingest(
                     converted_path, results_dir, [
@@ -264,8 +261,16 @@ class BasicSyntoolConverter(SyntoolConverter):
                 os.remove(converted_path)
             except IsADirectoryError:
                 shutil.rmtree(converted_path)
+        return results
 
-        self.post_ingest(results, results_dir, **kwargs)
+    def run(self, in_file, out_dir, **kwargs):
+        """Transforms a file into a Syntool-displayable format using
+        the syntool-converter and syntool-ingestor tools
+        """
+        results_dir = kwargs.pop('results_dir')
+        converted_paths = self.run_conversion(in_file, out_dir, kwargs)
+        results = self.run_ingestion(converted_paths, results_dir, kwargs)
+        self.post_ingest(results, results_dir, kwargs)
         return results
 
 

--- a/geospaas_processing/converters/syntool/converter.py
+++ b/geospaas_processing/converters/syntool/converter.py
@@ -342,12 +342,13 @@ class Sentinel3OLCISyntoolConverter(BasicSyntoolConverter):
             edited_kwargs['converter_options']['channels'] = channel
             try:
                 results.extend(super().run_conversion(in_file, out_dir, edited_kwargs))
-            except SystemExit:
-                # The sentinel3_olci_l2 converter exits without error
-                # message if the data quality is not satisfactory.
-                # We allow the conversion to continue for other bands.
-                logger.warning("Syntool conversion failed for %s", in_file, exc_info=True)
-                continue
+            except ConversionError as error:
+                if isinstance(error.__cause__, SystemExit):
+                    # The sentinel3_olci_l2 converter exits without error
+                    # message if the data quality is not satisfactory.
+                    # We allow the conversion to continue for other bands.
+                    logger.warning("Syntool conversion failed for %s", in_file, exc_info=True)
+                    continue
         return results
 
 

--- a/tests/converters/test_syntool_converters.py
+++ b/tests/converters/test_syntool_converters.py
@@ -408,10 +408,12 @@ class Sentinel3OLCISyntoolConverterTestCase(unittest.TestCase):
         """Test that SystemExit exceptions do not interrupt the
         conversion process but simply return empty results
         """
+        error = syntool_converter.ConversionError()
+        error.__cause__ = SystemExit()
         converter = syntool_converter.Sentinel3OLCISyntoolConverter(
             converter_type='foo',
             ingest_parameter_files='bar')
-        with mock.patch.object(converter, 'convert', side_effect=[SystemExit, ['conv2.tiff']]):
+        with mock.patch.object(converter, 'convert', side_effect=[error, ['conv2.tiff']]):
             with self.assertLogs(level=logging.WARNING):
                 results = converter.run_conversion(
                     'in.nc', 'out', {'converter_options': {'channels': ['baz', 'qux']}})

--- a/tests/converters/test_syntool_converters.py
+++ b/tests/converters/test_syntool_converters.py
@@ -91,7 +91,7 @@ class SyntoolConverterTestCase(unittest.TestCase):
             result_dir = Path(tmp_dir, 'result')
             result_dir.mkdir()
             syntool_converter.SyntoolConverter().post_ingest(
-                ['result'], tmp_dir, dataset=mock_dataset)
+                ['result'], tmp_dir, {'dataset': mock_dataset})
             with open(result_dir / 'features' / 'data_access.ini', 'r', encoding='utf-8') as handle:
                 contents = handle.read()
             self.assertEqual(
@@ -219,24 +219,43 @@ class BasicSyntoolConverterTestCase(unittest.TestCase):
             converter.parse_converter_args({'converter_options': {'ham': 'egg'}}),
             ['-t', 'foo', '-opt', 'bar=baz', 'ham=egg'])
 
-    def test_run(self):
-        """Test running the conversion and ingestion"""
+    def test_run_conversion(self):
+        """Test calling the Syntool converter on the input file"""
         converter = syntool_converter.BasicSyntoolConverter(
             converter_type='foo',
             ingest_parameter_files='bar')
         with mock.patch.object(converter, 'convert',
-                               return_value=['conv1.tiff', 'conv2']) as mock_convert, \
-             mock.patch.object(converter, 'ingest',
+                               return_value=['conv1.tiff', 'conv2']) as mock_convert:
+            results = converter.run_conversion('in.nc', 'out',
+                                               {'converter_options': {'baz': 'quz'}})
+        mock_convert.assert_called_once_with('in.nc', 'out', ['-t', 'foo', '-opt', 'baz=quz'])
+        self.assertListEqual(results, [Path('out', 'conv1.tiff'), Path('out', 'conv2')])
+
+    def test_run_conversion_no_converter(self):
+        """If no converter is set, run_conversion() should return the path to
+        the input file
+        """
+        converter = syntool_converter.BasicSyntoolConverter(
+            converter_type=None,
+            ingest_parameter_files='bar')
+        with mock.patch.object(converter, 'convert',) as mock_convert:
+            results = converter.run_conversion('in.nc', 'out', {})
+        mock_convert.assert_not_called()
+        self.assertListEqual(results, [Path('out', 'in.nc')])
+
+    def test_run_ingestion(self):
+        """Test calling the Syntool ingestor on the conversion output
+        file(s)
+        """
+        converter = syntool_converter.BasicSyntoolConverter(
+            converter_type='foo',
+            ingest_parameter_files='bar')
+        with mock.patch.object(converter, 'ingest',
                                side_effect=[['ingested_dir1'], ['ingested_dir2']]) as mock_ingest, \
-             mock.patch.object(converter, 'post_ingest') as mock_post_ingest, \
              mock.patch('os.remove', side_effect=(None, IsADirectoryError)) as mock_remove, \
              mock.patch('shutil.rmtree') as mock_rmtree:
-            converter.run(
-                in_file='in.nc',
-                out_dir='out',
-                results_dir='results',
-                converter_options={'baz': 'quz'})
-        mock_convert.assert_called_once_with('in.nc', 'out', ['-t', 'foo', '-opt', 'baz=quz'])
+            converter.run_ingestion(
+                [Path('out', 'conv1.tiff'), Path('out', 'conv2')], 'results', {})
         mock_ingest.assert_has_calls([
             mock.call(
                 Path('out', 'conv1.tiff'),
@@ -249,36 +268,35 @@ class BasicSyntoolConverterTestCase(unittest.TestCase):
                 ['--config', Path('parameters/3413.ini'),
                  '--options-file', converter.PARAMETERS_DIR / 'bar']),
         ])
-        mock_post_ingest.assert_called_once_with(['ingested_dir1', 'ingested_dir2'], 'results')
         mock_remove.assert_has_calls((
             mock.call(Path('out', 'conv1.tiff')),
             mock.call(Path('out', 'conv2'))))
         mock_rmtree.assert_called_once_with(Path('out', 'conv2'))
 
-    def test_run_no_converter(self):
-        """If no converter is set, convert() should return the path to
-        the input file
-        """
+    def test_run(self):
+        """Test running the conversion and ingestion"""
         converter = syntool_converter.BasicSyntoolConverter(
-            converter_type=None,
+            converter_type='foo',
             ingest_parameter_files='bar')
-        with mock.patch.object(converter, 'convert',) as mock_convert, \
-             mock.patch.object(converter, 'ingest',
-                               return_value=['ingested_dir1']) as mock_ingest, \
-             mock.patch.object(converter, 'post_ingest') as mock_post_ingest, \
-             mock.patch('os.remove') as mock_remove:
-            converter.run(
+        with mock.patch.object(converter, 'run_conversion',
+                               return_value=[Path('out', 'conv1.tiff'),
+                                             Path('out', 'conv2')]) as mock_conversion, \
+             mock.patch.object(converter, 'run_ingestion',
+                               return_value=['ingested_dir1', 'ingested_dir2']) as mock_ingestion, \
+             mock.patch.object(converter, 'post_ingest') as mock_post_ingest:
+            results = converter.run(
                 in_file='in.nc',
                 out_dir='out',
-                results_dir='results')
-        mock_convert.assert_not_called()
-        mock_ingest.assert_called_once_with(
-            Path('out', 'in.nc'),
+                results_dir='results',
+                converter_options={'baz': 'quz'})
+        self.assertListEqual(results, ['ingested_dir1', 'ingested_dir2'])
+        mock_conversion.assert_called_with('in.nc', 'out', {'converter_options': {'baz': 'quz'}})
+        mock_ingestion.assert_called_with(
+            [Path('out', 'conv1.tiff'), Path('out', 'conv2')],
             'results',
-            ['--config', Path('parameters/3413.ini'),
-             '--options-file', converter.PARAMETERS_DIR / 'bar'])
-        mock_post_ingest.assert_called_once_with(['ingested_dir1'], 'results')
-        mock_remove.assert_called_once_with(Path('out', 'in.nc'))
+            {'converter_options': {'baz': 'quz'}})
+        mock_post_ingest.assert_called_with(
+            ['ingested_dir1', 'ingested_dir2'], 'results', {'converter_options': {'baz': 'quz'}})
 
 
 class Sentinel1SyntoolConverterTestCase(unittest.TestCase):
@@ -351,6 +369,10 @@ class Sentinel1SyntoolConverterTestCase(unittest.TestCase):
             self.assertListEqual(
                 list(ingested_dir.iterdir()),
                 [ingested_dir / 'ingested_hh'])
+
+
+class Sentinel3OLCISyntoolConverterTestCase(unittest.TestCase):
+    """Tests for the Sentinel1SyntoolConverter class"""
 
 
 class CustomReaderSyntoolConverterTestCase(unittest.TestCase):


### PR DESCRIPTION
Add specific Syntool converter for Sentinel 3 OLCI L2 data.
The converter supports specifying a list of channels and runs the syntool-converter tool for each channel.