### PR TITLE
Add "in place" publishing

### DIFF
--- a/geospaas_processing/tasks/core.py
+++ b/geospaas_processing/tasks/core.py
@@ -138,45 +138,52 @@ def copy(self, args, copy_to=None):  # pylint: disable=unused-argument
 
 @app.task(base=FaultTolerantTask, bind=True, track_started=True)
 @lock_dataset_files
-def publish(self, args):  # pylint: disable=unused-argument
+def publish(self, args, publish_mode='in_place'):  # pylint: disable=unused-argument
     """Copy the file (tree) located at `args[1]` to the FTP server (using SCP)"""
     dataset_id = args[0]
     dataset_files_paths = args[1] or []
 
-    ftp_host = os.getenv('GEOSPAAS_PROCESSING_FTP_HOST', None)
-    ftp_root = os.getenv('GEOSPAAS_PROCESSING_FTP_ROOT', None)
-    ftp_path = os.getenv('GEOSPAAS_PROCESSING_FTP_PATH', None)
+    if publish_mode == 'in_place':
+        prefix = os.getenv('GEOSPAAS_PROCESSING_PUBLISH_PREFIX', '')
+        results = [
+            f"{prefix.rstrip('/')}/{p}"
+            for p in dataset_files_paths
+        ]
+    elif publish_mode == 'ftp':
+        ftp_host = os.getenv('GEOSPAAS_PROCESSING_FTP_HOST', None)
+        ftp_root = os.getenv('GEOSPAAS_PROCESSING_FTP_ROOT', None)
+        ftp_path = os.getenv('GEOSPAAS_PROCESSING_FTP_PATH', None)
 
-    if not (ftp_host and ftp_root and ftp_path):
-        raise RuntimeError(
-            'The following environment variables should be set: ' +
-            'GEOSPAAS_PROCESSING_FTP_HOST, ' +
-            'GEOSPAAS_PROCESSING_FTP_ROOT, ' +
-            'GEOSPAAS_PROCESSING_FTP_PATH.'
-        )
+        if not (ftp_host and ftp_root and ftp_path):
+            raise RuntimeError(
+                'The following environment variables should be set: ' +
+                'GEOSPAAS_PROCESSING_FTP_HOST, ' +
+                'GEOSPAAS_PROCESSING_FTP_ROOT, ' +
+                'GEOSPAAS_PROCESSING_FTP_PATH.'
+            )
 
-    # It is assumed that the remote server uses "/"" as path separator
-    remote_storage_path = posixpath.join(ftp_root, ftp_path)
-    ftp_storage = utils.RemoteStorage(host=ftp_host, path=remote_storage_path)
+        # It is assumed that the remote server uses "/"" as path separator
+        remote_storage_path = posixpath.join(ftp_root, ftp_path)
+        ftp_storage = utils.RemoteStorage(host=ftp_host, path=remote_storage_path)
 
-    logger.info("Checking if there is enough free space on %s:%s", ftp_host, remote_storage_path)
-    total_size = utils.LocalStorage(path=WORKING_DIRECTORY).get_files_size(dataset_files_paths)
-    ftp_storage.free_space(total_size)
+        logger.info("Checking if there is enough free space on %s:%s", ftp_host, remote_storage_path)
+        total_size = utils.LocalStorage(path=WORKING_DIRECTORY).get_files_size(dataset_files_paths)
+        ftp_storage.free_space(total_size)
 
-    results = []
-    for file in dataset_files_paths:
-        dataset_local_path = os.path.join(WORKING_DIRECTORY, file)
-        logger.info("Copying %s to %s:%s", dataset_local_path, ftp_host,
-                    os.path.join(remote_storage_path, file))
-        try:
-            ftp_storage.put(dataset_local_path, file)
-        except scp.SCPException as error:
-            if 'No space left on device' in str(error):
-                ftp_storage.remove(file)
-                self.retry((args,), countdown=90, max_retries=5)
-            else:
-                raise
-        results.append(f"ftp://{ftp_host}/{ftp_path}/{file}")
+        results = []
+        for file in dataset_files_paths:
+            dataset_local_path = os.path.join(WORKING_DIRECTORY, file)
+            logger.info("Copying %s to %s:%s", dataset_local_path, ftp_host,
+                        os.path.join(remote_storage_path, file))
+            try:
+                ftp_storage.put(dataset_local_path, file)
+            except scp.SCPException as error:
+                if 'No space left on device' in str(error):
+                    ftp_storage.remove(file)
+                    self.retry((args,), countdown=90, max_retries=5)
+                else:
+                    raise
+            results.append(f"ftp://{ftp_host}/{ftp_path}/{file}")
 
     return (dataset_id, results)
 

--- a/geospaas_processing/tasks/core.py
+++ b/geospaas_processing/tasks/core.py
@@ -198,18 +198,21 @@ def crop(self, args, bounding_box=None):
     if bounding_box is None:
         return args
     dataset_id = args[0]
+    bounding_box_str = '_'.join(str(i) for i in bounding_box)
     cropped_file_paths = []
     for dataset_file_path in args[1]:
         logger.debug("Cropping dataset %s file '%s'", dataset_id, dataset_file_path)
-        dataset_file_name, extension = os.path.splitext(os.path.basename(dataset_file_path))
-        cropped_file_path = os.path.join(
+        cropped_dir = os.path.join(
             os.path.dirname(dataset_file_path),
-            f"{dataset_file_name}_cropped{extension}")
+            f"cropped_{bounding_box_str}")
+        os.makedirs(os.path.join(WORKING_DIRECTORY, cropped_dir), exist_ok=True)
+        cropped_file_path = os.path.join(
+            cropped_dir,
+            os.path.basename(dataset_file_path))
         full_dataset_path = os.path.join(WORKING_DIRECTORY, dataset_file_path)
         full_cropped_path = os.path.join(WORKING_DIRECTORY, cropped_file_path)
         ops.crop(full_dataset_path, full_cropped_path, bounding_box)
-        os.rename(full_cropped_path, full_dataset_path)
-        cropped_file_paths.append(dataset_file_path)
+        cropped_file_paths.append(cropped_file_path)
     return (dataset_id, cropped_file_paths)
 
 

--- a/tests/tasks/test_core_tasks.py
+++ b/tests/tasks/test_core_tasks.py
@@ -248,9 +248,18 @@ class PublishTestCase(unittest.TestCase):
                             return_value=None), \
                  mock.patch('geospaas_processing.utils.RemoteStorage.__del__',
                             return_value=None):
-                tasks_core.publish((1, [file_name]))  # pylint: disable=no-value-for-parameter
+                tasks_core.publish((1, [file_name]), publish_mode='ftp')  # pylint: disable=no-value-for-parameter
             mock_free_space.assert_called()
             mock_put.assert_called()
+    
+    def test_publish_in_place(self):
+        """Test publishing 'in place'"""
+        previous_task_results = ['foo.nc', 'bar.nc']
+        prefix = 'http://baz/'
+        with mock.patch('os.getenv', return_value=prefix):
+            self.assertEqual(
+                tasks_core.publish((1, previous_task_results), publish_mode='in_place'),
+                (1, ['http://baz/foo.nc', 'http://baz/bar.nc']))
 
     def test_error_if_no_ftp_info(self):
         """An error must be raised if either of the FTP_ variables is not defined"""
@@ -258,7 +267,7 @@ class PublishTestCase(unittest.TestCase):
         del os.environ['GEOSPAAS_PROCESSING_FTP_ROOT']
         del os.environ['GEOSPAAS_PROCESSING_FTP_PATH']
         with self.assertRaises(RuntimeError):
-            tasks_core.publish((1, 'dataset.nc.tar.gz'))  # pylint: disable=no-value-for-parameter
+            tasks_core.publish((1, 'dataset.nc.tar.gz'), publish_mode='ftp')  # pylint: disable=no-value-for-parameter
 
     def test_no_space_left_error(self):
         """
@@ -280,7 +289,7 @@ class PublishTestCase(unittest.TestCase):
                  mock.patch('geospaas_processing.utils.RemoteStorage.__del__',
                             return_value=None):
                 with self.assertRaises(celery.exceptions.Retry):
-                    tasks_core.publish((1, [file_name]))  # pylint: disable=no-value-for-parameter
+                    tasks_core.publish((1, [file_name]), publish_mode='ftp')  # pylint: disable=no-value-for-parameter
             mock_remove.assert_called()
 
     def test_scp_error(self):
@@ -296,7 +305,7 @@ class PublishTestCase(unittest.TestCase):
                     mock.patch.object(utils.RemoteStorage, '__init__', return_value=None), \
                     mock.patch.object(utils.RemoteStorage, '__del__', return_value=None):
                 with self.assertRaises(scp.SCPException):
-                    tasks_core.publish((1, [file_name]))  # pylint: disable=no-value-for-parameter
+                    tasks_core.publish((1, [file_name]), publish_mode='ftp')  # pylint: disable=no-value-for-parameter
 
 
 class CropTestCase(unittest.TestCase):

--- a/tests/tasks/test_core_tasks.py
+++ b/tests/tasks/test_core_tasks.py
@@ -320,18 +320,14 @@ class CropTestCase(unittest.TestCase):
         mock_crop.assert_has_calls((
             mock.call(
                 '/tmp/test_data/foo.nc',
-                '/tmp/test_data/foo_cropped.nc',
+                '/tmp/test_data/cropped_1_2_3_4/foo.nc',
                 [1, 2, 3, 4]),
             mock.call(
                 '/tmp/test_data/bar.nc',
-                '/tmp/test_data/bar_cropped.nc',
+                '/tmp/test_data/cropped_1_2_3_4/bar.nc',
                 [1, 2, 3, 4]),
         ))
-        mock_rename.assert_has_calls([
-            mock.call('/tmp/test_data/foo_cropped.nc', '/tmp/test_data/foo.nc'),
-            mock.call('/tmp/test_data/bar_cropped.nc', '/tmp/test_data/bar.nc')
-        ])
-        self.assertEqual(result, (1, ['foo.nc', 'bar.nc']))
+        self.assertEqual(result, (1, ['cropped_1_2_3_4/foo.nc', 'cropped_1_2_3_4/bar.nc']))
 
     def test_crop_noop(self):
         """Nothing is done if no bounding box is provided"""


### PR DESCRIPTION
Just add a prefix to the task results, the files are not moved.
The working directory needs to be published by external means.

Also fixed an issue with cropped paths. The cropped files are now placed in a cropped_<bbox> folder in the same directory as the dataset file.