### PR TITLE
Update Syntool cleanup

### DIFF
--- a/geospaas_processing/provider_settings.yml
+++ b/geospaas_processing/provider_settings.yml
@@ -33,7 +33,7 @@
   totp_secret: !ENV 'CREODIAS_TOTP_SECRET'
   token_placement: 'url'
   token_parameter_name: 'token'
-'https://catalogue.dataspace.copernicus.eu':
+'https://download.dataspace.copernicus.eu':
   username: !ENV 'COPERNICUS_DATA_SPACE_USERNAME'
   password: !ENV 'COPERNICUS_DATA_SPACE_PASSWORD'
   authentication_type: 'oauth2'

--- a/geospaas_processing/provider_settings.yml
+++ b/geospaas_processing/provider_settings.yml
@@ -59,4 +59,7 @@
 'https://tds.aviso.altimetry.fr':
   username: !ENV AVISO_USERNAME
   password: !ENV AVISO_PASSWORD
+'https://tds-odatis.aviso.altimetry.fr':
+  username: !ENV AVISO_USERNAME
+  password: !ENV AVISO_PASSWORD
 ...

--- a/geospaas_processing/tasks/syntool.py
+++ b/geospaas_processing/tasks/syntool.py
@@ -6,14 +6,16 @@ import subprocess
 import tempfile
 from collections.abc import Mapping
 from contextlib import ExitStack
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import celery
+from django.db.models import F
 
 import geospaas_processing.converters.syntool
 import geospaas_processing.utils as utils
 from geospaas.catalog.models import Dataset
+from geospaas_processing.models import ProcessingResult
 from geospaas_processing.tasks import lock_dataset_files, FaultTolerantTask, WORKING_DIRECTORY
 from ..converters.syntool.converter import SyntoolConversionManager
 from ..models import ProcessingResult
@@ -177,15 +179,15 @@ def db_insert(self, args, **kwargs):
 
 
 @app.task(base=FaultTolerantTask, bind=True, track_started=True)
-def cleanup(self, criteria):
-    """Remove ingested files based on the provided criteria.
-    `criteria` is a dictionaryn of Django lookups used to select the
-    ProcessingResults to remove.
+def cleanup(self):
+    """Remove expired ingested files
     """
     syntool_database_host, syntool_database_name = get_db_config()
+
+    now = datetime.now(timezone.utc)
     processing_results = ProcessingResult.objects.filter(
         type=ProcessingResult.ProcessingResultType.SYNTOOL,
-        **criteria)
+        ttl__lt=now-F("created"))
 
     results_dir = os.getenv('GEOSPAAS_PROCESSING_SYNTOOL_RESULTS_DIR', WORKING_DIRECTORY)
 

--- a/tests/data/test_data.json
+++ b/tests/data/test_data.json
@@ -245,5 +245,27 @@
             "type": "syntool",
             "created": "2023-10-25T15:38:47.000Z"
         }
+    },
+    {
+        "model": "geospaas_processing.processingresult",
+        "pk": 2,
+        "fields": {
+            "dataset": 4,
+            "path": "ingested/product_name/granule_name_2/",
+            "type": "syntool",
+            "created": "2023-10-25T15:38:47.000Z",
+            "ttl": "1 00:00:00"
+        }
+    },
+    {
+        "model": "geospaas_processing.processingresult",
+        "pk": 3,
+        "fields": {
+            "dataset": 4,
+            "path": "ingested/product_name/granule_name_3/",
+            "type": "syntool",
+            "created": "2023-10-25T15:38:47.000Z",
+            "ttl": "10 00:00:00"
+        }
     }
 ]

--- a/tests/tasks/test_syntool_tasks.py
+++ b/tests/tasks/test_syntool_tasks.py
@@ -3,7 +3,7 @@ import logging
 import subprocess
 import unittest
 import unittest.mock as mock
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import django.test
@@ -241,49 +241,49 @@ class CleanupIngestedTestCase(django.test.TestCase):
         self.mock_rmtree = mock.patch('shutil.rmtree').start()
         self.mock_remove = mock.patch('os.remove').start()
         self.mock_run = mock.patch('subprocess.run').start()
-
-    def tearDown(self):
-        mock.patch.stopall()
+        self.mock_datetime = mock.patch('geospaas_processing.tasks.syntool.datetime').start()
+        self.mock_datetime.now.return_value = datetime(2023, 10, 27, tzinfo=timezone.utc)
+        self.addCleanup(mock.patch.stopall)
 
     def test_cleanup(self):
         """Test standard call, deleting based on creation date"""
-        expected_path = 'ingested/product_name/granule_name/'  # see fixture
+        expected_path = 'ingested/product_name/granule_name_2/'  # see fixture
         with self.assertLogs(tasks_syntool.logger):
-            self.assertListEqual(tasks_syntool.cleanup({'id': 1}), [expected_path])
+            self.assertListEqual(tasks_syntool.cleanup(), [expected_path])
         self.mock_rmtree.assert_called_with(Path(
             geospaas_processing.tasks.WORKING_DIRECTORY,
             expected_path))
         self.mock_run.assert_called_with(
             [
                 'mysql', '-h', 'db', 'syntool', '-e',
-                "DELETE FROM `product_product_name` WHERE dataset_name = 'granule_name';"
+                "DELETE FROM `product_product_name` WHERE dataset_name = 'granule_name_2';"
             ],
             capture_output=True,
             check=True)
-        self.assertFalse(ProcessingResult.objects.filter(id=1).exists())
+        self.assertFalse(ProcessingResult.objects.filter(id=2).exists())
 
     def test_cleanup_file(self):
         """Test deleting a file (usually won't happen)"""
         self.mock_rmtree.side_effect = NotADirectoryError
-        expected_path = 'ingested/product_name/granule_name/'  # see fixture
+        expected_path = 'ingested/product_name/granule_name_2/'  # see fixture
         with self.assertLogs(tasks_syntool.logger):
-            self.assertListEqual(tasks_syntool.cleanup({'id': 1}), [expected_path])
+            self.assertListEqual(tasks_syntool.cleanup(), [expected_path])
 
     def test_cleanup_file_not_found(self):
         """Test behavior when the result files are already deleted
         """
         self.mock_rmtree.side_effect = FileNotFoundError
-        expected_path = 'ingested/product_name/granule_name/'  # see fixture
+        expected_path = 'ingested/product_name/granule_name_2/'  # see fixture
         with self.assertLogs(tasks_syntool.logger, level=logging.WARNING):
-            self.assertListEqual(tasks_syntool.cleanup({'id': 1}), [expected_path])
+            self.assertListEqual(tasks_syntool.cleanup(), [expected_path])
 
     def test_cleanup_stale_file_handle(self):
         """Test behavior when a stale file handle error happens
         """
         self.mock_rmtree.side_effect = OSError(116, '[Errno 116] Stale file handle')
-        expected_path = 'ingested/product_name/granule_name/'  # see fixture
+        expected_path = 'ingested/product_name/granule_name_2/'  # see fixture
         with self.assertLogs(tasks_syntool.logger, level=logging.WARNING):
-            self.assertListEqual(tasks_syntool.cleanup({'id': 1}), [expected_path])
+            self.assertListEqual(tasks_syntool.cleanup(), [expected_path])
 
     def test_cleanup_file_subprocess_error(self):
         """Test behavior when an error occurs running the mysql command
@@ -292,4 +292,4 @@ class CleanupIngestedTestCase(django.test.TestCase):
         self.mock_run.side_effect = subprocess.CalledProcessError(1, '')
         with self.assertLogs(tasks_syntool.logger, level=logging.ERROR), \
              self.assertRaises(subprocess.CalledProcessError):
-            self.assertListEqual(tasks_syntool.cleanup({'id': 1}), [expected_path])
+            self.assertListEqual(tasks_syntool.cleanup(), [expected_path])


### PR DESCRIPTION
Make syntool cleanup remove expired Syntool processing results.
Makes things more efficient by not having to look for expired datasets on the client side.